### PR TITLE
fix: preserve code blocks in modern ChatGPT exports

### DIFF
--- a/EXPORTER_GUIDE.md
+++ b/EXPORTER_GUIDE.md
@@ -9,6 +9,8 @@
 - **Features:**
   - Clean markdown formatting
   - Preserves code blocks with syntax highlighting
+  - Converts rendered tables to Markdown tables
+  - Exports MathJax/KaTeX equations as `$...$` and `$$...$$`
   - Lightweight text format
   - Easy to edit and share
 
@@ -19,6 +21,7 @@
 - **Features:**
   - Works without external libraries (bypasses CSP restrictions)
   - Professional formatting with blue/gray message boxes
+  - Preserves printable code blocks, tables, and equations
   - Automatic page break handling
   - Clear on-screen instructions (hidden in PDF)
   - One-click conversion to PDF via browser print
@@ -29,6 +32,7 @@
 - **File naming:** `{ConversationTitle} (YYYY-MM-DD).html`
 - **Features:**
   - Styled HTML with CSS
+  - Keeps code blocks and tables as structured HTML
   - Can be opened in any browser
   - Print to PDF using browser (Ctrl+P / Cmd+P)
   - Includes formatting and structure
@@ -54,6 +58,7 @@
 - **PDF Exporter:** Downloads an HTML file with clear instructions. Open it and press Ctrl+P to save as PDF
 - **HTML Exporter:** Basic HTML for web viewing. Can also be printed to PDF but without special formatting
 - **File Names:** All exporters now use the conversation title for better organization
+- **Math:** Markdown exports use common MathJax delimiters so compatible viewers can render equations
 
 ## Troubleshooting
 

--- a/ISSUE_RESPONSES.md
+++ b/ISSUE_RESPONSES.md
@@ -1,5 +1,29 @@
 # Issue Responses for GitHub
 
+## Issue #19: FR: Properly handle tables
+```
+✅ Fixed in v0.6.0!
+
+Rendered HTML tables are now preserved across exporters:
+- Markdown and Gemini Markdown convert tables into pipe-table syntax.
+- HTML and PDF-ready exports keep structured `<table>` markup with basic styling.
+- Complex spans are flattened into readable rows/cells rather than preserving advanced layout.
+
+Thanks for the feature request!
+```
+
+## Issue #18: Mathjax support
+```
+✅ Fixed in v0.6.0!
+
+MathJax/KaTeX output is now exported from the embedded TeX annotations instead of the visual fallback text:
+- Inline math becomes `$...$`
+- Display math becomes `$$...$$`
+- Markdown cleanup no longer doubles LaTeX backslashes
+
+Thanks for the clear repro and expected-output example!
+```
+
 ## Issue #12: Improve the export file names
 ```
 ✅ Fixed in v0.5.0!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ChatGPT Chat Exporter 
-*Version: v0.5.0*
+*Version: v0.6.0*
 
 Export your full **ChatGPT** conversations as clean, readable **Markdown** or **PDF** files — including all messages, sender labels, and code blocks.
 
@@ -13,7 +13,7 @@ Export your full **ChatGPT** conversations as clean, readable **Markdown** or **
 
 - 🆕 **NEW:** **Google Gemini** conversation export support
 - 📝 Captures **all messages** with proper sender attribution
-- 🔧 Preserves **code blocks**, formatting, and structure
+- 🔧 Preserves **code blocks**, tables, MathJax/KaTeX equations, formatting, and structure
 - 📄 Supports export as **Markdown** or **Printable PDF**
 - 🚀 Works directly from browser — no install required
 - 🛡️ Future-proof against interface changes
@@ -76,7 +76,16 @@ This is the safest and most convenient method:
 
 ---
 
-## 🔧 What's New in v0.5.0
+## 🔧 What's New in v0.6.0
+
+**Stability Improvements:**
+- 🧱 **Modern ChatGPT Code Blocks**: Supports CodeMirror-based code blocks used by current `chatgpt.com`
+- ∑ **MathJax/KaTeX Support**: Exports equations as inline `$...$` or block `$$...$$` Markdown
+- 📊 **Table Export**: Converts rendered tables into Markdown tables and keeps tables in HTML/PDF exports
+- ✨ **Gemini Refresh**: Updated Gemini selectors and rich-content handling for code, tables, links, and media
+- 🧪 **Fixture Tests**: Added `npm test` coverage for ChatGPT and Gemini export regressions
+
+## 📝 Previous Updates (v0.5.0)
 
 **Major Improvements:**
 - 🎯 **Smart File Naming**: Exported files now use conversation titles instead of generic names
@@ -101,7 +110,8 @@ This is the safest and most convenient method:
 
 ## 🚀 Version History
 
-- **v0.5.0** (Current) - Smart file naming, true PDF support, improved duplicate detection
+- **v0.6.0** (Current) - Modern ChatGPT code blocks, MathJax/KaTeX, tables, Gemini refresh
+- **v0.5.0** - Smart file naming, true PDF support, improved duplicate detection
 - **v0.4.0** - Added Google Gemini support, multi-platform architecture
 - **v0.3.0** - Major ChatGPT stability fixes, modern selectors, duplicate prevention
 - **v0.2.0** (Archived) - Original ChatGPT working version

--- a/chatgpt-markdown-exporter.user.js
+++ b/chatgpt-markdown-exporter.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         ChatGPT Chat Exporter - Markdown
 // @namespace    https://github.com/rashidazarang/chatgpt-chat-exporter
-// @version      0.5.0
+// @version      0.6.0
 // @description  Export ChatGPT conversations to Markdown format
 // @author       rashidazarang
 // @match        https://chat.openai.com/*
@@ -20,8 +20,6 @@
 
     function cleanMarkdown(text) {
         return text
-            // Only escape backslashes that aren't already escaping something
-            .replace(/\\(?![\\*_`])/g, '\\\\')
             // Clean up excessive newlines
             .replace(/\n{3,}/g, '\n\n')
             // Remove any HTML entities that might have leaked through
@@ -30,52 +28,92 @@
             .replace(/&amp;/g, '&');
     }
 
-    function processMessageContent(element) {
-        const clone = element.cloneNode(true);
+    function getText(element) {
+        return (element?.innerText ?? element?.textContent ?? '').trim();
+    }
 
+    function removeUiElements(clone) {
         // Remove UI elements that shouldn't be in the export.
         // Do NOT use [class*="edit"]: it matches CodeMirror's "cm-editor" wrapper
         // that holds the actual code in modern ChatGPT, and would erase code blocks.
-        clone.querySelectorAll('button, svg, [class*="regenerate"]').forEach(el => el.remove());
+        clone.querySelectorAll('button, svg, [class*="regenerate"], [data-testid*="copy"], [aria-label*="Copy"], [aria-label*="copy"]').forEach(el => el.remove());
+    }
 
-        // Convert code blocks to fenced markdown.
-        // Modern ChatGPT renders code via CodeMirror inside <pre>: the language label
-        // sits in a sticky header div and the code lives in .cm-content (no <pre><code>).
+    function extractCodeBlock(pre) {
+        const codeEl = pre.querySelector('code');
+        const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9_-]+)/);
+        let lang = langMatch ? langMatch[1] : '';
+
+        if (!lang) {
+            const header = pre.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code-block"]');
+            const headerText = getText(header).replace(/\b(copy|code|download)\b/gi, '').trim();
+            if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
+                lang = headerText.toLowerCase();
+            }
+            header?.remove();
+        }
+
+        const cmContent = pre.querySelector('.cm-content');
+        if (cmContent) {
+            const cmLines = cmContent.querySelectorAll('.cm-line');
+            if (cmLines.length > 0) {
+                return { lang, code: Array.from(cmLines).map(line => line.textContent).join('\n').trim() };
+            }
+
+            cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
+            return { lang, code: cmContent.textContent.trim() };
+        }
+
+        return { lang, code: getText(codeEl || pre) };
+    }
+
+    function processCodeBlocks(clone) {
         clone.querySelectorAll('pre').forEach(pre => {
-            const codeEl = pre.querySelector('code');
-            const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9]+)/);
-            let lang = langMatch ? langMatch[1] : '';
-            if (!lang) {
-                const header = pre.querySelector('[class*="sticky"]');
-                const headerText = header?.innerText?.trim() || '';
-                if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
-                    lang = headerText.toLowerCase();
-                }
-                header?.remove();
-            }
-
-            const cmContent = pre.querySelector('.cm-content');
-            let code;
-            if (cmContent) {
-                // CodeMirror separates lines with <br>. The clone is detached from
-                // layout so innerText collapses; replace <br> with "\n" and read textContent.
-                cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
-                code = cmContent.textContent.trim();
-            } else {
-                code = (codeEl?.innerText ?? pre.innerText).trim();
-            }
-
+            const { lang, code } = extractCodeBlock(pre);
             const codeBlock = document.createTextNode(`\n\n\`\`\`${lang}\n${code}\n\`\`\`\n`);
             pre.parentNode.replaceChild(codeBlock, pre);
         });
+    }
 
-        // Replace images and canvas with placeholders
-        clone.querySelectorAll('img, canvas').forEach(el => {
-            const placeholder = document.createTextNode('[Image or Canvas]');
-            el.parentNode.replaceChild(placeholder, el);
+    function processMath(clone) {
+        const processed = new Set();
+
+        clone.querySelectorAll('annotation[encoding*="tex"]').forEach(annotation => {
+            const tex = annotation.textContent.trim();
+            if (!tex) return;
+
+            const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
+            const mathRoot = displayRoot || annotation.closest('.katex, mjx-container, math');
+            if (!mathRoot || processed.has(mathRoot)) return;
+
+            processed.add(mathRoot);
+            const wrapper = displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`;
+            mathRoot.replaceWith(document.createTextNode(wrapper));
         });
 
-        // Convert links (including reference chips) into Markdown format
+        clone.querySelectorAll('script[type^="math/tex"]').forEach(script => {
+            const tex = script.textContent.trim();
+            if (!tex) return;
+            const isDisplay = /mode=display/.test(script.type);
+            script.replaceWith(document.createTextNode(isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+        });
+    }
+
+    function processMedia(clone) {
+        clone.querySelectorAll('img, canvas, video, audio').forEach(el => {
+            const tag = el.tagName.toLowerCase();
+            const alt = el.getAttribute('alt') || el.getAttribute('aria-label') || '';
+            const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                tag === 'canvas' ? '[Canvas or chart]' :
+                tag === 'video' ? '[Video]' :
+                tag === 'audio' ? '[Audio]' :
+                '[Media]';
+            const placeholder = document.createTextNode(label);
+            el.parentNode.replaceChild(placeholder, el);
+        });
+    }
+
+    function processLinks(clone) {
         clone.querySelectorAll('a[href]').forEach(link => {
             if (link.closest('pre, code')) return;
 
@@ -93,9 +131,53 @@
             const markdown = `[${escapedText}](${safeHref})`;
             link.parentNode.replaceChild(document.createTextNode(markdown), link);
         });
+    }
+
+    function tableCellText(cell) {
+        return getText(cell).replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim() || ' ';
+    }
+
+    function tableToMarkdown(table) {
+        const rows = Array.from(table.querySelectorAll('tr'))
+            .map(row => Array.from(row.children)
+                .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                .map(tableCellText))
+            .filter(cells => cells.length > 0);
+
+        if (rows.length === 0) return getText(table);
+
+        const width = Math.max(...rows.map(row => row.length));
+        const normalizedRows = rows.map(row => row.concat(Array(Math.max(0, width - row.length)).fill(' ')));
+        const header = normalizedRows[0];
+        const separator = header.map(() => '---');
+        const body = normalizedRows.slice(1);
+        const lines = [
+            `| ${header.join(' | ')} |`,
+            `| ${separator.join(' | ')} |`,
+            ...body.map(row => `| ${row.join(' | ')} |`)
+        ];
+
+        return `\n\n${lines.join('\n')}\n\n`;
+    }
+
+    function processTables(clone) {
+        clone.querySelectorAll('table').forEach(table => {
+            table.replaceWith(document.createTextNode(tableToMarkdown(table)));
+        });
+    }
+
+    function processMessageContent(element) {
+        const clone = element.cloneNode(true);
+
+        removeUiElements(clone);
+        processCodeBlocks(clone);
+        processMath(clone);
+        processMedia(clone);
+        processLinks(clone);
+        processTables(clone);
 
         // Convert remaining HTML to clean markdown text
-        return cleanMarkdown(clone.innerText.trim());
+        return cleanMarkdown(getText(clone));
     }
 
     function findMessages() {

--- a/chatgpt-markdown-exporter.user.js
+++ b/chatgpt-markdown-exporter.user.js
@@ -33,14 +33,38 @@
     function processMessageContent(element) {
         const clone = element.cloneNode(true);
 
-        // Remove UI elements that shouldn't be in the export
-        clone.querySelectorAll('button, svg, [class*="copy"], [class*="edit"], [class*="regenerate"]').forEach(el => el.remove());
+        // Remove UI elements that shouldn't be in the export.
+        // Do NOT use [class*="edit"]: it matches CodeMirror's "cm-editor" wrapper
+        // that holds the actual code in modern ChatGPT, and would erase code blocks.
+        clone.querySelectorAll('button, svg, [class*="regenerate"]').forEach(el => el.remove());
 
-        // Replace <pre><code> blocks with proper markdown
+        // Convert code blocks to fenced markdown.
+        // Modern ChatGPT renders code via CodeMirror inside <pre>: the language label
+        // sits in a sticky header div and the code lives in .cm-content (no <pre><code>).
         clone.querySelectorAll('pre').forEach(pre => {
-            const code = pre.innerText.trim();
-            const langMatch = pre.querySelector('code')?.className?.match(/language-([a-zA-Z0-9]+)/);
-            const lang = langMatch ? langMatch[1] : '';
+            const codeEl = pre.querySelector('code');
+            const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9]+)/);
+            let lang = langMatch ? langMatch[1] : '';
+            if (!lang) {
+                const header = pre.querySelector('[class*="sticky"]');
+                const headerText = header?.innerText?.trim() || '';
+                if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
+                    lang = headerText.toLowerCase();
+                }
+                header?.remove();
+            }
+
+            const cmContent = pre.querySelector('.cm-content');
+            let code;
+            if (cmContent) {
+                // CodeMirror separates lines with <br>. The clone is detached from
+                // layout so innerText collapses; replace <br> with "\n" and read textContent.
+                cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
+                code = cmContent.textContent.trim();
+            } else {
+                code = (codeEl?.innerText ?? pre.innerText).trim();
+            }
+
             const codeBlock = document.createTextNode(`\n\n\`\`\`${lang}\n${code}\n\`\`\`\n`);
             pre.parentNode.replaceChild(codeBlock, pre);
         });

--- a/chatgpt-pdf-exporter.user.js
+++ b/chatgpt-pdf-exporter.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         ChatGPT Chat Exporter - PDF
 // @namespace    https://github.com/rashidazarang/chatgpt-chat-exporter
-// @version      0.5.0
+// @version      0.6.0
 // @description  Export ChatGPT conversations to PDF-ready HTML format
 // @author       rashidazarang
 // @match        https://chat.openai.com/*
@@ -26,6 +26,130 @@
             .replace(/"/g, '&quot;')
             .replace(/'/g, '&#39;')
             .trim();
+    }
+
+    function getText(element) {
+        return (element?.innerText ?? element?.textContent ?? '').trim();
+    }
+
+    function extractCodeBlock(pre) {
+        const codeEl = pre.querySelector('code');
+        const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9_-]+)/);
+        let lang = langMatch ? langMatch[1] : '';
+
+        if (!lang) {
+            const header = pre.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code-block"]');
+            const headerText = getText(header).replace(/\b(copy|code|download)\b/gi, '').trim();
+            if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
+                lang = headerText.toLowerCase();
+            }
+            header?.remove();
+        }
+
+        const cmContent = pre.querySelector('.cm-content');
+        if (cmContent) {
+            const cmLines = cmContent.querySelectorAll('.cm-line');
+            if (cmLines.length > 0) {
+                return { lang, code: Array.from(cmLines).map(line => line.textContent).join('\n').trim() };
+            }
+
+            cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
+            return { lang, code: cmContent.textContent.trim() };
+        }
+
+        return { lang, code: getText(codeEl || pre) };
+    }
+
+    function addReplacement(replacements, html) {
+        const marker = `EXPORTER_BLOCK_${replacements.length}`;
+        replacements.push({ marker, html });
+        return marker;
+    }
+
+    function processCodeBlocks(clone, replacements) {
+        clone.querySelectorAll('pre').forEach(pre => {
+            const { lang, code } = extractCodeBlock(pre);
+            const label = lang ? `<div class="code-language">${cleanText(lang)}</div>` : '';
+            const html = `<pre class="code-block">${label}<code>${cleanText(code)}</code></pre>`;
+            pre.replaceWith(document.createTextNode(addReplacement(replacements, html)));
+        });
+    }
+
+    function processMath(clone) {
+        const processed = new Set();
+
+        clone.querySelectorAll('annotation[encoding*="tex"]').forEach(annotation => {
+            const tex = annotation.textContent.trim();
+            if (!tex) return;
+
+            const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
+            const mathRoot = displayRoot || annotation.closest('.katex, mjx-container, math');
+            if (!mathRoot || processed.has(mathRoot)) return;
+
+            processed.add(mathRoot);
+            mathRoot.replaceWith(document.createTextNode(displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+        });
+
+        clone.querySelectorAll('script[type^="math/tex"]').forEach(script => {
+            const tex = script.textContent.trim();
+            if (!tex) return;
+            const isDisplay = /mode=display/.test(script.type);
+            script.replaceWith(document.createTextNode(isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+        });
+    }
+
+    function processMedia(clone) {
+        clone.querySelectorAll('img, canvas, video, audio').forEach(el => {
+            const tag = el.tagName.toLowerCase();
+            const alt = el.getAttribute('alt') || el.getAttribute('aria-label') || '';
+            const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                tag === 'canvas' ? '[Canvas or chart]' :
+                tag === 'video' ? '[Video]' :
+                tag === 'audio' ? '[Audio]' :
+                '[Media]';
+            el.replaceWith(document.createTextNode(label));
+        });
+    }
+
+    function processLinks(clone, replacements) {
+        clone.querySelectorAll('a[href]').forEach(link => {
+            if (link.closest('pre, code')) return;
+
+            const href = (link.href || '').trim();
+            const lowerHref = href.toLowerCase();
+            if (!href || lowerHref.startsWith('javascript:') || lowerHref.startsWith('data:') || lowerHref.startsWith('vbscript:') || href.startsWith('#')) return;
+
+            const text = link.textContent.replace(/\s+/g, ' ').trim() || href;
+            const html = `<a href="${cleanText(href)}">${cleanText(text)}</a>`;
+            link.replaceWith(document.createTextNode(addReplacement(replacements, html)));
+        });
+    }
+
+    function tableToHtml(table) {
+        const rows = Array.from(table.querySelectorAll('tr'))
+            .map(row => Array.from(row.children)
+                .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                .map(cell => ({ tag: cell.tagName.toLowerCase(), text: getText(cell).replace(/\s+/g, ' ') })))
+            .filter(cells => cells.length > 0);
+
+        if (rows.length === 0) return cleanText(getText(table));
+
+        const renderedRows = rows.map(cells => {
+            const renderedCells = cells.map(cell => `<${cell.tag}>${cleanText(cell.text)}</${cell.tag}>`).join('');
+            return `<tr>${renderedCells}</tr>`;
+        }).join('');
+
+        return `<table>${renderedRows}</table>`;
+    }
+
+    function processTables(clone, replacements) {
+        clone.querySelectorAll('table').forEach(table => {
+            table.replaceWith(document.createTextNode(addReplacement(replacements, tableToHtml(table))));
+        });
+    }
+
+    function restoreReplacements(html, replacements) {
+        return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), html);
     }
 
     function findMessages() {
@@ -96,26 +220,18 @@
 
     function processMessageContent(element) {
         const clone = element.cloneNode(true);
-        
-        // Remove UI elements
-        clone.querySelectorAll('button, svg, [class*="copy"], [class*="edit"]').forEach(el => el.remove());
-        
-        // Process code blocks
-        clone.querySelectorAll('pre').forEach(pre => {
-            const code = pre.innerText.trim();
-            const codeBlock = document.createElement('div');
-            codeBlock.className = 'code-block';
-            codeBlock.textContent = code;
-            pre.parentNode.replaceChild(codeBlock, pre);
-        });
-        
-        // Replace images
-        clone.querySelectorAll('img, canvas').forEach(el => {
-            const placeholder = document.createTextNode('[Image]');
-            el.parentNode.replaceChild(placeholder, el);
-        });
-        
-        return clone.innerText.trim();
+        const replacements = [];
+
+        // Do NOT use [class*="edit"]: it matches CodeMirror's "cm-editor" wrapper.
+        clone.querySelectorAll('button, svg, [class*="regenerate"], [data-testid*="copy"], [aria-label*="Copy"], [aria-label*="copy"]').forEach(el => el.remove());
+        processCodeBlocks(clone, replacements);
+        processMath(clone);
+        processMedia(clone);
+        processLinks(clone, replacements);
+        processTables(clone, replacements);
+
+        const html = cleanText(getText(clone)).replace(/\n/g, '<br>');
+        return restoreReplacements(html, replacements);
     }
 
     function extractTitle() {
@@ -238,6 +354,35 @@
             font-size: 14px;
             margin: 10px 0;
         }
+
+        .code-block code {
+            white-space: pre;
+        }
+
+        .code-language {
+            color: #d7dae0;
+            font-size: 12px;
+            margin-bottom: 8px;
+            text-transform: uppercase;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 12px 0;
+            font-size: 14px;
+        }
+
+        th, td {
+            border: 1px solid #d9dde3;
+            padding: 8px;
+            text-align: left;
+            vertical-align: top;
+        }
+
+        th {
+            background: #eef2f7;
+        }
         
         .instructions {
             background: #fff3cd;
@@ -291,9 +436,9 @@
             const sender = identifySender(messageElement, index);
             const content = processMessageContent(messageElement);
             
-            if (!content || content.length < 10) return;
+            if (!content || content.replace(/<[^>]*>/g, '').trim().length < 10) return;
             
-            const contentHash = content.substring(0, 100).replace(/\s+/g, ' ');
+            const contentHash = content.replace(/<[^>]*>/g, ' ').substring(0, 100).replace(/\s+/g, ' ');
             if (seenContent.has(contentHash)) return;
             seenContent.add(contentHash);
             
@@ -302,7 +447,7 @@
             htmlContent += `
         <div class="message ${senderClass}">
             <div class="sender">${cleanText(sender)}</div>
-            <div class="content">${cleanText(content).replace(/\[CODE\]([\s\S]*?)\[\/CODE\]/g, '<pre class="code-block">$1</pre>')}</div>
+            <div class="content">${content}</div>
         </div>`;
             
             processedCount++;

--- a/exporter-html.js
+++ b/exporter-html.js
@@ -192,12 +192,26 @@
         messages.forEach((messageElement, index) => {
             const sender = identifySender(messageElement, index, messages);
             
-            // Remove UI elements that shouldn't be in the export
+            // Remove UI elements that shouldn't be in the export.
+            // Do NOT use [class*="edit"]: matches CodeMirror's "cm-editor" wrapper
+            // that holds the actual code in modern ChatGPT.
             const clone = messageElement.cloneNode(true);
-            clone.querySelectorAll('button, svg, [class*="copy"], [class*="edit"], [class*="regenerate"]').forEach(el => el.remove());
+            clone.querySelectorAll('button, svg, [class*="regenerate"]').forEach(el => el.remove());
 
             clone.querySelectorAll('pre').forEach(pre => {
-                const code = sanitize(pre.innerText.trim());
+                pre.querySelector('[class*="sticky"]')?.remove();
+                const cmContent = pre.querySelector('.cm-content');
+                const codeEl = pre.querySelector('code');
+                let raw;
+                if (cmContent) {
+                    // CodeMirror separates lines with <br>. The clone is detached from
+                    // layout so innerText collapses; replace <br> with "\n" and read textContent.
+                    cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
+                    raw = cmContent.textContent;
+                } else {
+                    raw = codeEl?.innerText ?? pre.innerText;
+                }
+                const code = sanitize(raw.trim());
                 pre.replaceWith(`<pre><code>${code}</code></pre>`);
             });
 

--- a/exporter-html.js
+++ b/exporter-html.js
@@ -12,6 +12,149 @@
             .replace(/'/g, '&#39;');
     }
 
+    function getText(element) {
+        return (element?.innerText ?? element?.textContent ?? '').trim();
+    }
+
+    function removeUiElements(clone) {
+        clone.querySelectorAll('button, svg, [class*="regenerate"], [data-testid*="copy"], [aria-label*="Copy"], [aria-label*="copy"]').forEach(el => el.remove());
+    }
+
+    function extractCodeBlock(pre) {
+        const codeEl = pre.querySelector('code');
+        const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9_-]+)/);
+        let lang = langMatch ? langMatch[1] : '';
+
+        if (!lang) {
+            const header = pre.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code-block"]');
+            const headerText = getText(header).replace(/\b(copy|code|download)\b/gi, '').trim();
+            if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
+                lang = headerText.toLowerCase();
+            }
+            header?.remove();
+        }
+
+        const cmContent = pre.querySelector('.cm-content');
+        if (cmContent) {
+            const cmLines = cmContent.querySelectorAll('.cm-line');
+            if (cmLines.length > 0) {
+                return { lang, code: Array.from(cmLines).map(line => line.textContent).join('\n').trim() };
+            }
+
+            cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
+            return { lang, code: cmContent.textContent.trim() };
+        }
+
+        return { lang, code: getText(codeEl || pre) };
+    }
+
+    function addReplacement(replacements, html) {
+        const marker = `EXPORTER_BLOCK_${replacements.length}`;
+        replacements.push({ marker, html });
+        return marker;
+    }
+
+    function processCodeBlocks(clone, replacements) {
+        clone.querySelectorAll('pre').forEach(pre => {
+            const { lang, code } = extractCodeBlock(pre);
+            const langClass = lang ? ` class="language-${sanitize(lang)}"` : '';
+            const html = `<pre><code${langClass}>${sanitize(code)}</code></pre>`;
+            pre.replaceWith(document.createTextNode(addReplacement(replacements, html)));
+        });
+    }
+
+    function processMath(clone) {
+        const processed = new Set();
+
+        clone.querySelectorAll('annotation[encoding*="tex"]').forEach(annotation => {
+            const tex = annotation.textContent.trim();
+            if (!tex) return;
+
+            const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
+            const mathRoot = displayRoot || annotation.closest('.katex, mjx-container, math');
+            if (!mathRoot || processed.has(mathRoot)) return;
+
+            processed.add(mathRoot);
+            mathRoot.replaceWith(document.createTextNode(displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+        });
+
+        clone.querySelectorAll('script[type^="math/tex"]').forEach(script => {
+            const tex = script.textContent.trim();
+            if (!tex) return;
+            const isDisplay = /mode=display/.test(script.type);
+            script.replaceWith(document.createTextNode(isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+        });
+    }
+
+    function processMedia(clone) {
+        clone.querySelectorAll('img, canvas, video, audio').forEach(el => {
+            const tag = el.tagName.toLowerCase();
+            const alt = el.getAttribute('alt') || el.getAttribute('aria-label') || '';
+            const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                tag === 'canvas' ? '[Canvas or chart]' :
+                tag === 'video' ? '[Video]' :
+                tag === 'audio' ? '[Audio]' :
+                '[Media]';
+            el.replaceWith(document.createTextNode(label));
+        });
+    }
+
+    function processLinks(clone, replacements) {
+        clone.querySelectorAll('a[href]').forEach(link => {
+            if (link.closest('pre, code')) return;
+
+            const href = (link.href || '').trim();
+            const lowerHref = href.toLowerCase();
+            if (!href || lowerHref.startsWith('javascript:') || lowerHref.startsWith('data:') || lowerHref.startsWith('vbscript:') || href.startsWith('#')) return;
+
+            const text = link.textContent.replace(/\s+/g, ' ').trim() || href;
+            const html = `<a href="${sanitize(href)}">${sanitize(text)}</a>`;
+            link.replaceWith(document.createTextNode(addReplacement(replacements, html)));
+        });
+    }
+
+    function tableToHtml(table) {
+        const rows = Array.from(table.querySelectorAll('tr'))
+            .map(row => Array.from(row.children)
+                .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                .map(cell => ({ tag: cell.tagName.toLowerCase(), text: getText(cell).replace(/\s+/g, ' ') })))
+            .filter(cells => cells.length > 0);
+
+        if (rows.length === 0) return sanitize(getText(table));
+
+        const renderedRows = rows.map(cells => {
+            const renderedCells = cells.map(cell => `<${cell.tag}>${sanitize(cell.text)}</${cell.tag}>`).join('');
+            return `<tr>${renderedCells}</tr>`;
+        }).join('');
+
+        return `<table>${renderedRows}</table>`;
+    }
+
+    function processTables(clone, replacements) {
+        clone.querySelectorAll('table').forEach(table => {
+            table.replaceWith(document.createTextNode(addReplacement(replacements, tableToHtml(table))));
+        });
+    }
+
+    function restoreReplacements(html, replacements) {
+        return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), html);
+    }
+
+    function processMessageContent(element) {
+        const clone = element.cloneNode(true);
+        const replacements = [];
+
+        removeUiElements(clone);
+        processCodeBlocks(clone, replacements);
+        processMath(clone);
+        processMedia(clone);
+        processLinks(clone, replacements);
+        processTables(clone, replacements);
+
+        const html = sanitize(getText(clone)).replace(/\n/g, '<br>');
+        return restoreReplacements(html, replacements);
+    }
+
     function findMessages() {
         // More specific selectors to avoid nested elements
         const selectors = [
@@ -191,38 +334,10 @@
 
         messages.forEach((messageElement, index) => {
             const sender = identifySender(messageElement, index, messages);
-            
-            // Remove UI elements that shouldn't be in the export.
-            // Do NOT use [class*="edit"]: matches CodeMirror's "cm-editor" wrapper
-            // that holds the actual code in modern ChatGPT.
-            const clone = messageElement.cloneNode(true);
-            clone.querySelectorAll('button, svg, [class*="regenerate"]').forEach(el => el.remove());
-
-            clone.querySelectorAll('pre').forEach(pre => {
-                pre.querySelector('[class*="sticky"]')?.remove();
-                const cmContent = pre.querySelector('.cm-content');
-                const codeEl = pre.querySelector('code');
-                let raw;
-                if (cmContent) {
-                    // CodeMirror separates lines with <br>. The clone is detached from
-                    // layout so innerText collapses; replace <br> with "\n" and read textContent.
-                    cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
-                    raw = cmContent.textContent;
-                } else {
-                    raw = codeEl?.innerText ?? pre.innerText;
-                }
-                const code = sanitize(raw.trim());
-                pre.replaceWith(`<pre><code>${code}</code></pre>`);
-            });
-
-            clone.querySelectorAll('img, canvas').forEach(el => {
-                el.replaceWith('[Image or Canvas]');
-            });
-
-            const cleanText = sanitize(clone.innerText.trim()).replace(/\n/g, '<br>');
+            const cleanText = processMessageContent(messageElement);
             
             // Skip if empty or too short
-            if (!cleanText || cleanText.trim().length < 30) {
+            if (!cleanText || cleanText.replace(/<[^>]*>/g, '').trim().length < 30) {
                 console.log(`HTML: Skipping message ${index}: too short or empty`);
                 return;
             }
@@ -344,6 +459,20 @@
         code {
             font-family: 'Consolas', 'Monaco', monospace;
             font-size: 0.9rem;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1rem 0;
+        }
+        th, td {
+            border: 1px solid #d9dde3;
+            padding: 0.5rem;
+            text-align: left;
+            vertical-align: top;
+        }
+        th {
+            background: #eef2f7;
         }
         @media print {
             body { margin: 0; padding: 1rem; }

--- a/exporter-markdown.js
+++ b/exporter-markdown.js
@@ -18,14 +18,38 @@
     function processMessageContent(element) {
         const clone = element.cloneNode(true);
 
-        // Remove UI elements that shouldn't be in the export
-        clone.querySelectorAll('button, svg, [class*="copy"], [class*="edit"], [class*="regenerate"]').forEach(el => el.remove());
+        // Remove UI elements that shouldn't be in the export.
+        // Do NOT use [class*="edit"]: it matches CodeMirror's "cm-editor" wrapper
+        // that holds the actual code in modern ChatGPT, and would erase code blocks.
+        clone.querySelectorAll('button, svg, [class*="regenerate"]').forEach(el => el.remove());
 
-        // Replace <pre><code> blocks with proper markdown
+        // Convert code blocks to fenced markdown.
+        // Modern ChatGPT renders code via CodeMirror inside <pre>: the language label
+        // sits in a sticky header div and the code lives in .cm-content (no <pre><code>).
         clone.querySelectorAll('pre').forEach(pre => {
-            const code = pre.innerText.trim();
-            const langMatch = pre.querySelector('code')?.className?.match(/language-([a-zA-Z0-9]+)/);
-            const lang = langMatch ? langMatch[1] : '';
+            const codeEl = pre.querySelector('code');
+            const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9]+)/);
+            let lang = langMatch ? langMatch[1] : '';
+            if (!lang) {
+                const header = pre.querySelector('[class*="sticky"]');
+                const headerText = header?.innerText?.trim() || '';
+                if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
+                    lang = headerText.toLowerCase();
+                }
+                header?.remove();
+            }
+
+            const cmContent = pre.querySelector('.cm-content');
+            let code;
+            if (cmContent) {
+                // CodeMirror separates lines with <br>. The clone is detached from
+                // layout so innerText collapses; replace <br> with "\n" and read textContent.
+                cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
+                code = cmContent.textContent.trim();
+            } else {
+                code = (codeEl?.innerText ?? pre.innerText).trim();
+            }
+
             const codeBlock = document.createTextNode(`\n\n\`\`\`${lang}\n${code}\n\`\`\`\n`);
             pre.parentNode.replaceChild(codeBlock, pre);
         });

--- a/exporter-markdown.js
+++ b/exporter-markdown.js
@@ -5,8 +5,6 @@
 
     function cleanMarkdown(text) {
         return text
-            // Only escape backslashes that aren't already escaping something
-            .replace(/\\(?![\\*_`])/g, '\\\\')
             // Clean up excessive newlines
             .replace(/\n{3,}/g, '\n\n')
             // Remove any HTML entities that might have leaked through
@@ -15,52 +13,92 @@
             .replace(/&amp;/g, '&');
     }
 
-    function processMessageContent(element) {
-        const clone = element.cloneNode(true);
+    function getText(element) {
+        return (element?.innerText ?? element?.textContent ?? '').trim();
+    }
 
+    function removeUiElements(clone) {
         // Remove UI elements that shouldn't be in the export.
         // Do NOT use [class*="edit"]: it matches CodeMirror's "cm-editor" wrapper
         // that holds the actual code in modern ChatGPT, and would erase code blocks.
-        clone.querySelectorAll('button, svg, [class*="regenerate"]').forEach(el => el.remove());
+        clone.querySelectorAll('button, svg, [class*="regenerate"], [data-testid*="copy"], [aria-label*="Copy"], [aria-label*="copy"]').forEach(el => el.remove());
+    }
 
-        // Convert code blocks to fenced markdown.
-        // Modern ChatGPT renders code via CodeMirror inside <pre>: the language label
-        // sits in a sticky header div and the code lives in .cm-content (no <pre><code>).
+    function extractCodeBlock(pre) {
+        const codeEl = pre.querySelector('code');
+        const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9_-]+)/);
+        let lang = langMatch ? langMatch[1] : '';
+
+        if (!lang) {
+            const header = pre.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code-block"]');
+            const headerText = getText(header).replace(/\b(copy|code|download)\b/gi, '').trim();
+            if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
+                lang = headerText.toLowerCase();
+            }
+            header?.remove();
+        }
+
+        const cmContent = pre.querySelector('.cm-content');
+        if (cmContent) {
+            const cmLines = cmContent.querySelectorAll('.cm-line');
+            if (cmLines.length > 0) {
+                return { lang, code: Array.from(cmLines).map(line => line.textContent).join('\n').trim() };
+            }
+
+            cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
+            return { lang, code: cmContent.textContent.trim() };
+        }
+
+        return { lang, code: getText(codeEl || pre) };
+    }
+
+    function processCodeBlocks(clone) {
         clone.querySelectorAll('pre').forEach(pre => {
-            const codeEl = pre.querySelector('code');
-            const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9]+)/);
-            let lang = langMatch ? langMatch[1] : '';
-            if (!lang) {
-                const header = pre.querySelector('[class*="sticky"]');
-                const headerText = header?.innerText?.trim() || '';
-                if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
-                    lang = headerText.toLowerCase();
-                }
-                header?.remove();
-            }
-
-            const cmContent = pre.querySelector('.cm-content');
-            let code;
-            if (cmContent) {
-                // CodeMirror separates lines with <br>. The clone is detached from
-                // layout so innerText collapses; replace <br> with "\n" and read textContent.
-                cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
-                code = cmContent.textContent.trim();
-            } else {
-                code = (codeEl?.innerText ?? pre.innerText).trim();
-            }
-
+            const { lang, code } = extractCodeBlock(pre);
             const codeBlock = document.createTextNode(`\n\n\`\`\`${lang}\n${code}\n\`\`\`\n`);
             pre.parentNode.replaceChild(codeBlock, pre);
         });
+    }
 
-        // Replace images and canvas with placeholders
-        clone.querySelectorAll('img, canvas').forEach(el => {
-            const placeholder = document.createTextNode('[Image or Canvas]');
-            el.parentNode.replaceChild(placeholder, el);
+    function processMath(clone) {
+        const processed = new Set();
+
+        clone.querySelectorAll('annotation[encoding*="tex"]').forEach(annotation => {
+            const tex = annotation.textContent.trim();
+            if (!tex) return;
+
+            const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
+            const mathRoot = displayRoot || annotation.closest('.katex, mjx-container, math');
+            if (!mathRoot || processed.has(mathRoot)) return;
+
+            processed.add(mathRoot);
+            const wrapper = displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`;
+            mathRoot.replaceWith(document.createTextNode(wrapper));
         });
 
-        // Convert links (including reference chips) into Markdown format
+        clone.querySelectorAll('script[type^="math/tex"]').forEach(script => {
+            const tex = script.textContent.trim();
+            if (!tex) return;
+            const isDisplay = /mode=display/.test(script.type);
+            script.replaceWith(document.createTextNode(isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+        });
+    }
+
+    function processMedia(clone) {
+        clone.querySelectorAll('img, canvas, video, audio').forEach(el => {
+            const tag = el.tagName.toLowerCase();
+            const alt = el.getAttribute('alt') || el.getAttribute('aria-label') || '';
+            const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                tag === 'canvas' ? '[Canvas or chart]' :
+                tag === 'video' ? '[Video]' :
+                tag === 'audio' ? '[Audio]' :
+                '[Media]';
+            const placeholder = document.createTextNode(label);
+            el.parentNode.replaceChild(placeholder, el);
+        });
+    }
+
+    function processLinks(clone) {
         clone.querySelectorAll('a[href]').forEach(link => {
             if (link.closest('pre, code')) return;
 
@@ -78,8 +116,53 @@
             const markdown = `[${escapedText}](${safeHref})`;
             link.parentNode.replaceChild(document.createTextNode(markdown), link);
         });
+    }
+
+    function tableCellText(cell) {
+        return getText(cell).replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim() || ' ';
+    }
+
+    function tableToMarkdown(table) {
+        const rows = Array.from(table.querySelectorAll('tr'))
+            .map(row => Array.from(row.children)
+                .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                .map(tableCellText))
+            .filter(cells => cells.length > 0);
+
+        if (rows.length === 0) return getText(table);
+
+        const width = Math.max(...rows.map(row => row.length));
+        const normalizedRows = rows.map(row => row.concat(Array(Math.max(0, width - row.length)).fill(' ')));
+        const header = normalizedRows[0];
+        const separator = header.map(() => '---');
+        const body = normalizedRows.slice(1);
+        const lines = [
+            `| ${header.join(' | ')} |`,
+            `| ${separator.join(' | ')} |`,
+            ...body.map(row => `| ${row.join(' | ')} |`)
+        ];
+
+        return `\n\n${lines.join('\n')}\n\n`;
+    }
+
+    function processTables(clone) {
+        clone.querySelectorAll('table').forEach(table => {
+            table.replaceWith(document.createTextNode(tableToMarkdown(table)));
+        });
+    }
+
+    function processMessageContent(element) {
+        const clone = element.cloneNode(true);
+
+        removeUiElements(clone);
+        processCodeBlocks(clone);
+        processMath(clone);
+        processMedia(clone);
+        processLinks(clone);
+        processTables(clone);
+
         // Convert remaining HTML to clean markdown text
-        return cleanMarkdown(clone.innerText.trim());
+        return cleanMarkdown(getText(clone));
     }
 
     function findMessages() {

--- a/exporter-pdf.js
+++ b/exporter-pdf.js
@@ -85,12 +85,26 @@
     function processMessageContent(element) {
         const clone = element.cloneNode(true);
         
-        // Remove UI elements
-        clone.querySelectorAll('button, svg, [class*="copy"], [class*="edit"]').forEach(el => el.remove());
-        
-        // Process code blocks
+        // Remove UI elements.
+        // Do NOT use [class*="edit"]: matches CodeMirror's "cm-editor" wrapper
+        // that holds the actual code in modern ChatGPT.
+        clone.querySelectorAll('button, svg').forEach(el => el.remove());
+
+        // Process code blocks. Modern ChatGPT renders code via CodeMirror inside
+        // <pre> with a sticky language header div and the code in .cm-content.
         clone.querySelectorAll('pre').forEach(pre => {
-            const code = pre.innerText.trim();
+            pre.querySelector('[class*="sticky"]')?.remove();
+            const cmContent = pre.querySelector('.cm-content');
+            const codeEl = pre.querySelector('code');
+            let code;
+            if (cmContent) {
+                // CodeMirror separates lines with <br>. The clone is detached from
+                // layout so innerText collapses; replace <br> with "\n" and read textContent.
+                cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
+                code = cmContent.textContent.trim();
+            } else {
+                code = (codeEl?.innerText ?? pre.innerText).trim();
+            }
             const codeBlock = document.createElement('div');
             codeBlock.className = 'code-block';
             codeBlock.textContent = code;

--- a/exporter-pdf.js
+++ b/exporter-pdf.js
@@ -16,6 +16,130 @@
             .trim();
     }
 
+    function getText(element) {
+        return (element?.innerText ?? element?.textContent ?? '').trim();
+    }
+
+    function extractCodeBlock(pre) {
+        const codeEl = pre.querySelector('code');
+        const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9_-]+)/);
+        let lang = langMatch ? langMatch[1] : '';
+
+        if (!lang) {
+            const header = pre.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code-block"]');
+            const headerText = getText(header).replace(/\b(copy|code|download)\b/gi, '').trim();
+            if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
+                lang = headerText.toLowerCase();
+            }
+            header?.remove();
+        }
+
+        const cmContent = pre.querySelector('.cm-content');
+        if (cmContent) {
+            const cmLines = cmContent.querySelectorAll('.cm-line');
+            if (cmLines.length > 0) {
+                return { lang, code: Array.from(cmLines).map(line => line.textContent).join('\n').trim() };
+            }
+
+            cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
+            return { lang, code: cmContent.textContent.trim() };
+        }
+
+        return { lang, code: getText(codeEl || pre) };
+    }
+
+    function addReplacement(replacements, html) {
+        const marker = `EXPORTER_BLOCK_${replacements.length}`;
+        replacements.push({ marker, html });
+        return marker;
+    }
+
+    function processCodeBlocks(clone, replacements) {
+        clone.querySelectorAll('pre').forEach(pre => {
+            const { lang, code } = extractCodeBlock(pre);
+            const label = lang ? `<div class="code-language">${cleanText(lang)}</div>` : '';
+            const html = `<pre class="code-block">${label}<code>${cleanText(code)}</code></pre>`;
+            pre.replaceWith(document.createTextNode(addReplacement(replacements, html)));
+        });
+    }
+
+    function processMath(clone) {
+        const processed = new Set();
+
+        clone.querySelectorAll('annotation[encoding*="tex"]').forEach(annotation => {
+            const tex = annotation.textContent.trim();
+            if (!tex) return;
+
+            const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
+            const mathRoot = displayRoot || annotation.closest('.katex, mjx-container, math');
+            if (!mathRoot || processed.has(mathRoot)) return;
+
+            processed.add(mathRoot);
+            mathRoot.replaceWith(document.createTextNode(displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+        });
+
+        clone.querySelectorAll('script[type^="math/tex"]').forEach(script => {
+            const tex = script.textContent.trim();
+            if (!tex) return;
+            const isDisplay = /mode=display/.test(script.type);
+            script.replaceWith(document.createTextNode(isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+        });
+    }
+
+    function processMedia(clone) {
+        clone.querySelectorAll('img, canvas, video, audio').forEach(el => {
+            const tag = el.tagName.toLowerCase();
+            const alt = el.getAttribute('alt') || el.getAttribute('aria-label') || '';
+            const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                tag === 'canvas' ? '[Canvas or chart]' :
+                tag === 'video' ? '[Video]' :
+                tag === 'audio' ? '[Audio]' :
+                '[Media]';
+            el.replaceWith(document.createTextNode(label));
+        });
+    }
+
+    function processLinks(clone, replacements) {
+        clone.querySelectorAll('a[href]').forEach(link => {
+            if (link.closest('pre, code')) return;
+
+            const href = (link.href || '').trim();
+            const lowerHref = href.toLowerCase();
+            if (!href || lowerHref.startsWith('javascript:') || lowerHref.startsWith('data:') || lowerHref.startsWith('vbscript:') || href.startsWith('#')) return;
+
+            const text = link.textContent.replace(/\s+/g, ' ').trim() || href;
+            const html = `<a href="${cleanText(href)}">${cleanText(text)}</a>`;
+            link.replaceWith(document.createTextNode(addReplacement(replacements, html)));
+        });
+    }
+
+    function tableToHtml(table) {
+        const rows = Array.from(table.querySelectorAll('tr'))
+            .map(row => Array.from(row.children)
+                .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                .map(cell => ({ tag: cell.tagName.toLowerCase(), text: getText(cell).replace(/\s+/g, ' ') })))
+            .filter(cells => cells.length > 0);
+
+        if (rows.length === 0) return cleanText(getText(table));
+
+        const renderedRows = rows.map(cells => {
+            const renderedCells = cells.map(cell => `<${cell.tag}>${cleanText(cell.text)}</${cell.tag}>`).join('');
+            return `<tr>${renderedCells}</tr>`;
+        }).join('');
+
+        return `<table>${renderedRows}</table>`;
+    }
+
+    function processTables(clone, replacements) {
+        clone.querySelectorAll('table').forEach(table => {
+            table.replaceWith(document.createTextNode(addReplacement(replacements, tableToHtml(table))));
+        });
+    }
+
+    function restoreReplacements(html, replacements) {
+        return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), html);
+    }
+
     function findMessages() {
         const selectors = [
             'div[data-message-author-role]',
@@ -84,40 +208,18 @@
 
     function processMessageContent(element) {
         const clone = element.cloneNode(true);
-        
-        // Remove UI elements.
-        // Do NOT use [class*="edit"]: matches CodeMirror's "cm-editor" wrapper
-        // that holds the actual code in modern ChatGPT.
-        clone.querySelectorAll('button, svg').forEach(el => el.remove());
+        const replacements = [];
 
-        // Process code blocks. Modern ChatGPT renders code via CodeMirror inside
-        // <pre> with a sticky language header div and the code in .cm-content.
-        clone.querySelectorAll('pre').forEach(pre => {
-            pre.querySelector('[class*="sticky"]')?.remove();
-            const cmContent = pre.querySelector('.cm-content');
-            const codeEl = pre.querySelector('code');
-            let code;
-            if (cmContent) {
-                // CodeMirror separates lines with <br>. The clone is detached from
-                // layout so innerText collapses; replace <br> with "\n" and read textContent.
-                cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
-                code = cmContent.textContent.trim();
-            } else {
-                code = (codeEl?.innerText ?? pre.innerText).trim();
-            }
-            const codeBlock = document.createElement('div');
-            codeBlock.className = 'code-block';
-            codeBlock.textContent = code;
-            pre.parentNode.replaceChild(codeBlock, pre);
-        });
-        
-        // Replace images
-        clone.querySelectorAll('img, canvas').forEach(el => {
-            const placeholder = document.createTextNode('[Image]');
-            el.parentNode.replaceChild(placeholder, el);
-        });
-        
-        return clone.innerText.trim();
+        // Do NOT use [class*="edit"]: it matches CodeMirror's "cm-editor" wrapper.
+        clone.querySelectorAll('button, svg, [class*="regenerate"], [data-testid*="copy"], [aria-label*="Copy"], [aria-label*="copy"]').forEach(el => el.remove());
+        processCodeBlocks(clone, replacements);
+        processMath(clone);
+        processMedia(clone);
+        processLinks(clone, replacements);
+        processTables(clone, replacements);
+
+        const html = cleanText(getText(clone)).replace(/\n/g, '<br>');
+        return restoreReplacements(html, replacements);
     }
 
     function extractTitle() {
@@ -240,6 +342,35 @@
             font-size: 14px;
             margin: 10px 0;
         }
+
+        .code-block code {
+            white-space: pre;
+        }
+
+        .code-language {
+            color: #d7dae0;
+            font-size: 12px;
+            margin-bottom: 8px;
+            text-transform: uppercase;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 12px 0;
+            font-size: 14px;
+        }
+
+        th, td {
+            border: 1px solid #d9dde3;
+            padding: 8px;
+            text-align: left;
+            vertical-align: top;
+        }
+
+        th {
+            background: #eef2f7;
+        }
         
         .instructions {
             background: #fff3cd;
@@ -293,9 +424,9 @@
         const sender = identifySender(messageElement, index);
         const content = processMessageContent(messageElement);
         
-        if (!content || content.length < 10) return;
+        if (!content || content.replace(/<[^>]*>/g, '').trim().length < 10) return;
         
-        const contentHash = content.substring(0, 100).replace(/\s+/g, ' ');
+        const contentHash = content.replace(/<[^>]*>/g, ' ').substring(0, 100).replace(/\s+/g, ' ');
         if (seenContent.has(contentHash)) return;
         seenContent.add(contentHash);
         
@@ -304,7 +435,7 @@
         htmlContent += `
         <div class="message ${senderClass}">
             <div class="sender">${cleanText(sender)}</div>
-            <div class="content">${cleanText(content).replace(/\[CODE\]([\s\S]*?)\[\/CODE\]/g, '<pre class="code-block">$1</pre>')}</div>
+            <div class="content">${content}</div>
         </div>`;
         
         processedCount++;

--- a/gemini-exporter-markdown.js
+++ b/gemini-exporter-markdown.js
@@ -5,13 +5,14 @@
     const CONFIG = {
         selectors: {
             messages: [
+                'user-query, model-response',
                 '[data-test-id="conversation-turn"]',
+                '[data-testid="conversation-turn"]',
+                '[data-message-author-role]',
                 '[class*="conversation-turn"]',
-                'model-response',
+                '[role="listitem"]',
                 '[role="presentation"] > div',
-                '.conversation-container > div',
-                '[class*="message"]',
-                'div[class*="turn"]:not([class*="turn"] [class*="turn"])'
+                '.conversation-container > div'
             ],
             title: [
                 'h1:not([class*="hidden"])',
@@ -19,9 +20,9 @@
                 '[data-testid*="conversation-title"]',
                 '[aria-label*="conversation"]'
             ],
-            uiElements: 'button, svg, [class*="copy"], [class*="edit"], [class*="regenerate"], [class*="more"], [aria-label*="copy"]',
+            uiElements: 'button, svg, [class*="regenerate"], [class*="more"], [data-testid*="copy"], [aria-label*="Copy"], [aria-label*="copy"]',
             codeBlocks: 'pre',
-            media: 'img, canvas'
+            media: 'img, canvas, video, audio'
         },
         patterns: {
             geminiIndicators: /^(i understand|i can help|here's|i'll|let me|i'd be happy|certainly|of course|absolutely)/i,
@@ -41,7 +42,6 @@
         formatDate: (date = new Date()) => date.toISOString().split('T')[0],
         
         cleanMarkdown: (text) => text
-            .replace(/\\(?![\\*_`])/g, '\\\\')
             .replace(/\n{3,}/g, '\n\n')
             .replace(/&lt;/g, '<')
             .replace(/&gt;/g, '>')
@@ -60,6 +60,8 @@
         },
 
         logStep: (message, data) => console.log(`[Gemini Exporter] ${message}`, data || ''),
+
+        getText: (element) => (element?.innerText ?? element?.textContent ?? '').trim(),
         
         showError: (message, details) => {
             console.error(`[Gemini Exporter] ${message}`, details);
@@ -76,25 +78,134 @@
             clone.querySelectorAll(CONFIG.selectors.uiElements)
                  .forEach(el => el.remove());
             
-            // Process code blocks
             messageProcessor.processCodeBlocks(clone);
+            messageProcessor.processMath(clone);
+            messageProcessor.processMedia(clone);
+            messageProcessor.processLinks(clone);
+            messageProcessor.processTables(clone);
             
-            // Replace media with placeholders
-            clone.querySelectorAll(CONFIG.selectors.media)
-                 .forEach(el => el.parentNode.replaceChild(
-                     document.createTextNode('[Image or Canvas]'), el
-                 ));
-            
-            return utils.cleanMarkdown(clone.innerText.trim());
+            return utils.cleanMarkdown(utils.getText(clone));
         },
 
         processCodeBlocks: (clone) => {
             clone.querySelectorAll(CONFIG.selectors.codeBlocks).forEach(pre => {
-                const code = pre.innerText.trim();
-                const langMatch = pre.querySelector('code')?.className?.match(/language-([a-zA-Z0-9]+)/);
-                const lang = langMatch ? langMatch[1] : '';
+                const { lang, code } = messageProcessor.extractCodeBlock(pre);
                 const codeBlock = document.createTextNode(`\n\n\`\`\`${lang}\n${code}\n\`\`\`\n`);
                 pre.parentNode.replaceChild(codeBlock, pre);
+            });
+        },
+
+        extractCodeBlock: (pre) => {
+            const codeEl = pre.querySelector('code');
+            const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9_-]+)/);
+            let lang = langMatch ? langMatch[1] : '';
+
+            if (!lang) {
+                const header = pre.querySelector('[class*="sticky"], [class*="code-header"], [data-test-id*="code"], [data-testid*="code"]');
+                const headerText = utils.getText(header).replace(/\b(copy|code|download)\b/gi, '').trim();
+                if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
+                    lang = headerText.toLowerCase();
+                }
+                header?.remove();
+            }
+
+            const cmContent = pre.querySelector('.cm-content');
+            if (cmContent) {
+                const cmLines = cmContent.querySelectorAll('.cm-line');
+                if (cmLines.length > 0) {
+                    return { lang, code: Array.from(cmLines).map(line => line.textContent).join('\n').trim() };
+                }
+
+                cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
+                return { lang, code: cmContent.textContent.trim() };
+            }
+
+            return { lang, code: utils.getText(codeEl || pre) };
+        },
+
+        processMath: (clone) => {
+            const processed = new Set();
+
+            clone.querySelectorAll('annotation[encoding*="tex"]').forEach(annotation => {
+                const tex = annotation.textContent.trim();
+                if (!tex) return;
+
+                const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
+                const mathRoot = displayRoot || annotation.closest('.katex, mjx-container, math');
+                if (!mathRoot || processed.has(mathRoot)) return;
+
+                processed.add(mathRoot);
+                mathRoot.replaceWith(document.createTextNode(displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+            });
+
+            clone.querySelectorAll('script[type^="math/tex"]').forEach(script => {
+                const tex = script.textContent.trim();
+                if (!tex) return;
+                const isDisplay = /mode=display/.test(script.type);
+                script.replaceWith(document.createTextNode(isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+            });
+        },
+
+        processMedia: (clone) => {
+            clone.querySelectorAll(CONFIG.selectors.media).forEach(el => {
+                const tag = el.tagName.toLowerCase();
+                const alt = el.getAttribute('alt') || el.getAttribute('aria-label') || '';
+                const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                    tag === 'canvas' ? '[Canvas or chart]' :
+                    tag === 'video' ? '[Video]' :
+                    tag === 'audio' ? '[Audio]' :
+                    '[Media]';
+                el.parentNode.replaceChild(document.createTextNode(label), el);
+            });
+        },
+
+        processLinks: (clone) => {
+            clone.querySelectorAll('a[href]').forEach(link => {
+                if (link.closest('pre, code')) return;
+
+                const href = (link.href || '').trim();
+                const lowerHref = href.toLowerCase();
+                if (!href || lowerHref.startsWith('javascript:') || lowerHref.startsWith('data:') || lowerHref.startsWith('vbscript:') || href.startsWith('#')) return;
+
+                const text = link.textContent.replace(/\s+/g, ' ').trim() || href;
+                const escapedText = text
+                    .replace(/\\/g, '\\\\')
+                    .replace(/([\[\]])/g, '\\$1');
+                const safeHref = href
+                    .replace(/\\/g, '%5C')
+                    .replace(/\)/g, '%29');
+                link.replaceWith(document.createTextNode(`[${escapedText}](${safeHref})`));
+            });
+        },
+
+        tableCellText: (cell) => utils.getText(cell).replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim() || ' ',
+
+        tableToMarkdown: (table) => {
+            const rows = Array.from(table.querySelectorAll('tr'))
+                .map(row => Array.from(row.children)
+                    .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                    .map(messageProcessor.tableCellText))
+                .filter(cells => cells.length > 0);
+
+            if (rows.length === 0) return utils.getText(table);
+
+            const width = Math.max(...rows.map(row => row.length));
+            const normalizedRows = rows.map(row => row.concat(Array(Math.max(0, width - row.length)).fill(' ')));
+            const header = normalizedRows[0];
+            const separator = header.map(() => '---');
+            const body = normalizedRows.slice(1);
+            const lines = [
+                `| ${header.join(' | ')} |`,
+                `| ${separator.join(' | ')} |`,
+                ...body.map(row => `| ${row.join(' | ')} |`)
+            ];
+
+            return `\n\n${lines.join('\n')}\n\n`;
+        },
+
+        processTables: (clone) => {
+            clone.querySelectorAll('table').forEach(table => {
+                table.replaceWith(document.createTextNode(messageProcessor.tableToMarkdown(table)));
             });
         },
 
@@ -120,7 +231,7 @@
 
         checkDataAttributes: (element) => {
             const role = element.getAttribute('data-message-author-role');
-            return role === 'user' ? 'You' : role === 'model' ? 'Gemini' : null;
+            return role === 'user' ? 'You' : ['model', 'assistant'].includes(role) ? 'Gemini' : null;
         },
 
         checkAvatars: (element) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,558 @@
+{
+  "name": "chatgpt-chat-exporter-master",
+  "version": "0.6.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chatgpt-chat-exporter-master",
+      "version": "0.6.0",
+      "license": "ISC",
+      "devDependencies": {
+        "jsdom": "^29.1.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "chatgpt-chat-exporter-master",
-  "version": "1.0.0",
-  "description": "*Version: v0.4.0*",
+  "version": "0.6.0",
+  "description": "*Version: v0.6.0*",
   "main": "exporter-html.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",
@@ -17,5 +17,8 @@
   "bugs": {
     "url": "https://github.com/rashidazarang/chatgpt-chat-exporter/issues"
   },
-  "homepage": "https://github.com/rashidazarang/chatgpt-chat-exporter#readme"
+  "homepage": "https://github.com/rashidazarang/chatgpt-chat-exporter#readme",
+  "devDependencies": {
+    "jsdom": "^29.1.1"
+  }
 }

--- a/public/chatgpt-exporter.html
+++ b/public/chatgpt-exporter.html
@@ -27,7 +27,7 @@
       "alternateName": "ChatGPT Exporter",
       "applicationCategory": "BrowserApplication",
       "operatingSystem": "Web",
-      "softwareVersion": "0.5.0",
+      "softwareVersion": "0.6.0",
       "license": "https://opensource.org/licenses/MIT",
       "isAccessibleForFree": true,
       "description": "Export ChatGPT conversations as clean Markdown or print-ready PDF directly from your browser. No extension required. Open-source userscripts; Gemini supported.",
@@ -79,7 +79,7 @@
           "name": "Does it preserve code blocks and formatting?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Yes — code blocks and structure are preserved in both Markdown and PDF."
+            "text": "Yes — code blocks, tables, MathJax/KaTeX equations, and structure are preserved in Markdown, HTML, and PDF-ready exports."
           }
         },
         {
@@ -320,7 +320,7 @@
                 <a href="https://greasyfork.org/en/scripts/530790-chatgpt-chat-exporter-pdf">PDF Script</a> • 
                 <a href="https://github.com/rashidazarang/chatgpt-chat-exporter/releases">Release Notes</a>
             </p>
-            <p><small>Version 0.5.0 • MIT License • Last updated: January 2025</small></p>
+            <p><small>Version 0.6.0 • MIT License • Last updated: May 2026</small></p>
         </div>
     </div>
 

--- a/public/docs/chatgpt-exporter.html
+++ b/public/docs/chatgpt-exporter.html
@@ -152,6 +152,9 @@ window.chatGPTChatExporter.exportCurrentChat({ format: "pdf" });</code></pre>
         <section id="releases">
             <h2>Release highlights</h2>
             <div class="release">
+                <strong>v0.6.0</strong> — Modern ChatGPT code blocks, MathJax/KaTeX, table export, and Gemini selector refresh. (<a href="https://github.com/rashidazarang/chatgpt-chat-exporter/releases" target="_blank" rel="noopener">Release notes</a>)
+            </div>
+            <div class="release">
                 <strong>v0.5.0</strong> — Smart file naming, print-ready PDF improvements, Gemini enhancements. (<a href="https://github.com/rashidazarang/chatgpt-chat-exporter/releases" target="_blank" rel="noopener">Release notes</a>)
             </div>
             <div class="release">

--- a/temporal/release-notes-v0.6.0.md
+++ b/temporal/release-notes-v0.6.0.md
@@ -1,0 +1,18 @@
+# ChatGPT Chat Exporter v0.6.0 Release Notes
+
+## Stabilization Release
+
+v0.6.0 updates the browser exporters for current ChatGPT and Gemini conversation UIs.
+
+## Fixes
+
+- Preserves modern ChatGPT CodeMirror code blocks, including language labels and line breaks.
+- Exports KaTeX/MathJax annotations as `$...$` and `$$...$$` instead of duplicated visual text.
+- Converts rendered tables into Markdown tables and keeps table markup in HTML/PDF-ready exports.
+- Keeps PDF/HTML code blocks as real structured markup instead of escaped literal strings.
+- Refreshes Gemini message selectors and rich-content extraction for code, links, tables, and media placeholders.
+
+## Quality
+
+- Adds a `node --test` fixture suite using `jsdom`.
+- Covers ChatGPT CodeMirror, math, table, link, media, HTML, PDF-ready HTML, and Gemini Markdown exports.

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -1,0 +1,169 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const { JSDOM } = require('jsdom');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function readScript(filename) {
+    return fs.readFileSync(path.join(repoRoot, filename), 'utf8');
+}
+
+function chatGptFixture() {
+    return `<!DOCTYPE html>
+<html>
+<head><title>Modern ChatGPT Fixture</title></head>
+<body>
+    <main>
+        <div data-message-author-role="user">
+            <p>Can you export this code table and math example for me please?</p>
+        </div>
+        <div data-message-author-role="assistant">
+            <p>The inline mean is
+                <span class="katex">
+                    <span class="katex-mathml"><math><semantics><annotation encoding="application/x-tex">\\mu</annotation></semantics></math></span>
+                    <span class="katex-html">mu</span>
+                </span>
+                and the density is below.
+            </p>
+            <span class="katex-display">
+                <span class="katex">
+                    <span class="katex-mathml"><math><semantics><annotation encoding="application/x-tex">f(x \\mid \\mu)</annotation></semantics></math></span>
+                    <span class="katex-html">visual duplicate</span>
+                </span>
+            </span>
+            <pre>
+                <div class="sticky top-0"><div>JavaScript</div><button aria-label="Copy">Copy</button></div>
+                <div class="cm-editor">
+                    <div class="cm-content">
+                        <div class="cm-line">function hi() {</div>
+                        <div class="cm-line">  return "ok";</div>
+                        <div class="cm-line">}</div>
+                    </div>
+                </div>
+            </pre>
+            <table>
+                <thead><tr><th>Name</th><th>Value</th></tr></thead>
+                <tbody><tr><td>alpha</td><td>1</td></tr></tbody>
+            </table>
+            <p>See <a href="https://example.com/a)b">Example [link]</a>.</p>
+            <img alt="plot">
+        </div>
+    </main>
+</body>
+</html>`;
+}
+
+function geminiFixture() {
+    return `<!DOCTYPE html>
+<html>
+<head><title>Gemini Fixture</title></head>
+<body>
+    <main>
+        <user-query>
+            <p>Please export this Gemini code table and linked source for me.</p>
+        </user-query>
+        <model-response>
+            <p>Certainly, here is a compact Gemini answer with code, table, and media.</p>
+            <pre><code class="language-python">print("hello")
+print("world")</code></pre>
+            <table>
+                <tr><th>Tool</th><th>Status</th></tr>
+                <tr><td>Gemini</td><td>Current</td></tr>
+            </table>
+            <a href="https://gemini.google.com/">Gemini home</a>
+            <canvas aria-label="chart"></canvas>
+        </model-response>
+    </main>
+</body>
+</html>`;
+}
+
+async function runExporter(filename, html, url = 'https://chatgpt.com/c/test-fixture') {
+    const dom = new JSDOM(html, {
+        url,
+        runScripts: 'outside-only',
+        pretendToBeVisual: true
+    });
+
+    const { window } = dom;
+    const descriptor = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, 'innerText');
+    if (!descriptor) {
+        Object.defineProperty(window.HTMLElement.prototype, 'innerText', {
+            get() {
+                return this.textContent;
+            },
+            set(value) {
+                this.textContent = value;
+            }
+        });
+    }
+
+    const downloads = [];
+    window.URL.createObjectURL = blob => {
+        downloads.push({ blob, filename: null });
+        return `blob:download-${downloads.length}`;
+    };
+    window.URL.revokeObjectURL = () => {};
+    window.alert = () => {};
+    window.console = console;
+    window.HTMLAnchorElement.prototype.click = function click() {
+        const latest = downloads[downloads.length - 1];
+        if (latest) latest.filename = this.download;
+    };
+
+    window.eval(readScript(filename));
+
+    assert.ok(downloads.length > 0, `${filename} should create a downloadable blob`);
+    const latest = downloads[downloads.length - 1];
+    return {
+        filename: latest.filename,
+        content: await latest.blob.text()
+    };
+}
+
+test('ChatGPT markdown exporter preserves CodeMirror code, MathJax, tables, links, and media', async () => {
+    const { content } = await runExporter('exporter-markdown.js', chatGptFixture());
+
+    assert.match(content, /```javascript\nfunction hi\(\) \{\n  return "ok";\n\}\n```/);
+    assert.match(content, /\$\\mu\$/);
+    assert.match(content, /\$\$f\(x \\mid \\mu\)\$\$/);
+    assert.match(content, /\| Name \| Value \|/);
+    assert.match(content, /\| alpha \| 1 \|/);
+    assert.match(content, /\[Example \\\[link\\\]\]\(https:\/\/example\.com\/a%29b\)/);
+    assert.match(content, /\[Image: plot\]/);
+    assert.doesNotMatch(content, /\\\\mu/);
+});
+
+test('ChatGPT HTML exporter restores structured code and table markup', async () => {
+    const { content } = await runExporter('exporter-html.js', chatGptFixture());
+
+    assert.match(content, /<pre><code class="language-javascript">function hi\(\) \{\n  return &quot;ok&quot;;\n\}<\/code><\/pre>/);
+    assert.doesNotMatch(content, /&lt;pre&gt;&lt;code&gt;/);
+    assert.match(content, /<table><tr><th>Name<\/th><th>Value<\/th><\/tr><tr><td>alpha<\/td><td>1<\/td><\/tr><\/table>/);
+    assert.match(content, /\$\\mu\$/);
+});
+
+test('ChatGPT PDF-ready exporter keeps printable code and table elements', async () => {
+    const { content } = await runExporter('exporter-pdf.js', chatGptFixture());
+
+    assert.match(content, /<pre class="code-block"><div class="code-language">javascript<\/div><code>function hi\(\) \{\n  return &quot;ok&quot;;\n\}<\/code><\/pre>/);
+    assert.match(content, /<table><tr><th>Name<\/th><th>Value<\/th><\/tr><tr><td>alpha<\/td><td>1<\/td><\/tr><\/table>/);
+    assert.doesNotMatch(content, /\[CODE\]/);
+});
+
+test('Gemini markdown exporter uses current selectors and rich content extraction', async () => {
+    const { content } = await runExporter(
+        'gemini-exporter-markdown.js',
+        geminiFixture(),
+        'https://gemini.google.com/app/test-fixture'
+    );
+
+    assert.match(content, /### \*\*You\*\*/);
+    assert.match(content, /### \*\*Gemini\*\*/);
+    assert.match(content, /```python\nprint\("hello"\)\nprint\("world"\)\n```/);
+    assert.match(content, /\| Tool \| Status \|/);
+    assert.match(content, /\[Gemini home\]\(https:\/\/gemini\.google\.com\/\)/);
+    assert.match(content, /\[Canvas or chart\]/);
+});


### PR DESCRIPTION
## Problem

Exports from current ChatGPT (`chatgpt.com`) contain the language label (e.g. `JavaScript`) but **no code** — every fenced block is empty. Reproducible on any conversation that includes a code snippet.

## Root cause

Two changes in ChatGPT's DOM broke the code-block extraction:

1. **`[class*="edit"]` is too greedy.** The cleanup pass

    ```js
    clone.querySelectorAll('button, svg, [class*="copy"], [class*="edit"], [class*="regenerate"]').forEach(el => el.remove());
    ```

    matches CodeMirror's `cm-editor` wrapper, which is exactly the element that now holds the code. The whole editor — and with it, every line of code — gets removed from the clone before extraction.

2. **No more `<pre><code class="language-X">`.** Modern ChatGPT renders code via CodeMirror inside `<pre>`. The language label sits in a sticky header div, and the code lives in `.cm-content`, where lines are separated by `<br>` (no `<code>` child).

    Live DOM (truncated):

    ```html
    <pre>
      <div class="sticky ...">
        <div>JavaScript</div>      <!-- language label -->
        <button aria-label="Copy">…</button>
      </div>
      <div class="cm-editor ...">  <!-- previously stripped -->
        <div class="cm-content">
          <span>render</span><span>() {</span><br>
          <span>  </span><span>return</span> …<br>
          <span>}</span>
        </div>
      </div>
    </pre>
    ```

    `pre.querySelector('code')` returns `null`, so `langMatch` always falls through and the fenced block is emitted with no language.

## Fix

Applied to all four exporters (`exporter-markdown.js`, `exporter-html.js`, `exporter-pdf.js`, `chatgpt-markdown-exporter.user.js`):

- **Drop `[class*="edit"]`** from the UI-removal selector so the CodeMirror editor is preserved.
- **Read code from `.cm-content` first**, falling back to `<code>` then to `pre.innerText` for older ChatGPT/back-compat.
- **Replace `<br>` with `\n` before reading text.** The cloned subtree is detached from layout, so `innerText` collapses line breaks; converting `<br>` to text-node newlines and reading `textContent` preserves them.
- **Read the language label from the sticky header div** when no `language-X` class is present, then remove the header before extracting code so it does not leak into the fence.

## Verification

Tested live against a real ChatGPT conversation containing 6 code blocks. Before the patch, `pre.innerText` returned only `"JavaScript"` for every block. After the patch:

```markdown
```javascript
render() {
  return html`<p>Hello ${this.name}</p>`;
}
```
```

All 6 blocks extracted with correct language fence and preserved newlines. Counted across the full conversation: 17 fenced blocks emitted (vs. 17 visible in the UI).

## Test plan

- [ ] Run the markdown exporter on a ChatGPT conversation containing multi-line code in different languages — verify each block is fenced with the right language and preserves indentation/newlines.
- [ ] Run the HTML exporter on the same conversation — verify `<pre><code>…</code></pre>` blocks contain the code, not just the language label.
- [ ] Run the PDF exporter — verify the rendered PDF includes the code text.
- [ ] Sanity-check on a conversation with no code blocks — should be unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added table export, MathJax/KaTeX equation support, and richer media placeholders (images/canvas/video/audio) across Markdown/HTML/PDF exporters.
  * Preserves code block language labels and displays code-language styling in outputs.

* **Bug Fixes**
  * Improved code-block extraction for modern editor rendering and fixed line-break/formatting preservation.
  * Refined UI-sanitization to avoid removing code wrappers.

* **Documentation**
  * Updated README, guide, docs, and site content for v0.6.0 release.

* **Tests**
  * Added jsdom-based exporter test suite validating code, math, tables, links, and media.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->