### PR TITLE
Rewrite live chat extraction engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Dependency directories
 node_modules/
+
+# Local-only live reverse-engineering captures. These can contain private
+# authenticated DOM/network evidence and must never be committed.
+private-research/
 npm-debug.log
 yarn-debug.log
 yarn-error.log
@@ -33,4 +37,4 @@ agent-orchestra/
 airtable-ai-agent/
 mcp-ide-playbooks/
 mcp-intelligence/
-test-npm-install/ 
+test-npm-install/

--- a/EXPORTER_GUIDE.md
+++ b/EXPORTER_GUIDE.md
@@ -2,6 +2,8 @@
 
 ## Available Exporters
 
+All shipped exporters are generated from the shared engine in `src/extraction-engine.js`. The console scripts remain self-contained and pasteable; the userscripts embed the same engine at build time.
+
 ### 1. **exporter-markdown.js** - Markdown Export
 - **Output:** `.md` files
 - **Best for:** Text editors, GitHub, documentation
@@ -11,6 +13,7 @@
   - Preserves code blocks with syntax highlighting
   - Converts rendered tables to Markdown tables
   - Exports MathJax/KaTeX equations as `$...$` and `$$...$$`
+  - Adds readable placeholders for images, charts, media, files, and artifacts
   - Lightweight text format
   - Easy to edit and share
 
@@ -22,6 +25,7 @@
   - Works without external libraries (bypasses CSP restrictions)
   - Professional formatting with blue/gray message boxes
   - Preserves printable code blocks, tables, and equations
+  - Keeps media and file/artifact cards as readable placeholders
   - Automatic page break handling
   - Clear on-screen instructions (hidden in PDF)
   - One-click conversion to PDF via browser print
@@ -33,6 +37,7 @@
 - **Features:**
   - Styled HTML with CSS
   - Keeps code blocks and tables as structured HTML
+  - Keeps links, media placeholders, and file/artifact placeholders
   - Can be opened in any browser
   - Print to PDF using browser (Ctrl+P / Cmd+P)
   - Includes formatting and structure
@@ -44,6 +49,10 @@
 3. **Copy the entire contents** of your chosen exporter file
 4. **Paste in console** and press Enter
 5. **File will download automatically**
+
+## Google Gemini
+
+Use `gemini-exporter-markdown.js` from a conversation at `gemini.google.com/app`. The Gemini adapter looks for current `user-query`, `model-response`, `message-content`, and `code-block` structures before falling back to broader selectors.
 
 ## Quick Comparison
 
@@ -59,6 +68,8 @@
 - **HTML Exporter:** Basic HTML for web viewing. Can also be printed to PDF but without special formatting
 - **File Names:** All exporters now use the conversation title for better organization
 - **Math:** Markdown exports use common MathJax delimiters so compatible viewers can render equations
+- **Compatibility:** v0.7.0 is based on a local live Chrome/Crawlio audit of current ChatGPT and Gemini rendering. Raw authenticated captures are not included in the repository.
+- **Development:** Run `npm run build` after editing `src/extraction-engine.js`; `npm test` verifies generated scripts are up to date and runs jsdom fixture coverage.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ChatGPT Chat Exporter 
-*Version: v0.6.0*
+*Version: v0.7.0*
 
 Export your full **ChatGPT** conversations as clean, readable **Markdown** or **PDF** files — including all messages, sender labels, and code blocks.
 
-> **🎯 Major Update:** Added **Google Gemini** support! Now exports conversations from both ChatGPT and Gemini with the same high-quality accuracy.
+> **Compatibility Update:** v0.7.0 rewrites extraction around a shared engine informed by a live Chrome/Crawlio audit of current ChatGPT and Gemini rendering. No private live captures are included in this repository.
 
 ![ChatGPT Chat Exporter in action](demo/demo.gif)
 
@@ -11,12 +11,12 @@ Export your full **ChatGPT** conversations as clean, readable **Markdown** or **
 
 ## ✅ Features
 
-- 🆕 **NEW:** **Google Gemini** conversation export support
+- 🆕 **Google Gemini** conversation export support
 - 📝 Captures **all messages** with proper sender attribution
-- 🔧 Preserves **code blocks**, tables, MathJax/KaTeX equations, formatting, and structure
+- 🔧 Preserves **CodeMirror/code blocks**, tables, MathJax/KaTeX equations, formatting, lists, links, media placeholders, and basic file/artifact cards
 - 📄 Supports export as **Markdown** or **Printable PDF**
 - 🚀 Works directly from browser — no install required
-- 🛡️ Future-proof against interface changes
+- 🛡️ Shared provider adapters reduce drift between console exporters and userscripts
   
 ---
 
@@ -76,7 +76,16 @@ This is the safest and most convenient method:
 
 ---
 
-## 🔧 What's New in v0.6.0
+## 🔧 What's New in v0.7.0
+
+**Live Compatibility Rewrite:**
+- 🧭 **Shared Extraction Engine**: ChatGPT console scripts, Gemini console script, and userscripts now embed one canonical extraction engine generated from `src/extraction-engine.js`
+- 🧱 **Provider Adapters**: ChatGPT uses `data-message-author-role` first; Gemini uses current `user-query` / `model-response` custom elements first
+- 🧩 **Modern Rich Content**: Handles CodeMirror, custom `code-block`, tables, links/citations, MathJax/KaTeX/TeX annotations, media placeholders, and basic file/artifact cards
+- 🧪 **Expanded Synthetic Fixtures**: Tests cover live-observed ChatGPT and Gemini DOM shapes without including private authenticated captures
+- 🔒 **Private Audit Boundary**: v0.7.0 is based on a local live Chrome/Crawlio compatibility audit; raw captures remain private and untracked
+
+## 📝 Previous Updates (v0.6.0)
 
 **Stability Improvements:**
 - 🧱 **Modern ChatGPT Code Blocks**: Supports CodeMirror-based code blocks used by current `chatgpt.com`
@@ -110,7 +119,8 @@ This is the safest and most convenient method:
 
 ## 🚀 Version History
 
-- **v0.6.0** (Current) - Modern ChatGPT code blocks, MathJax/KaTeX, tables, Gemini refresh
+- **v0.7.0** (Current) - Shared extraction engine, live Chrome/Crawlio compatibility audit, current ChatGPT/Gemini provider adapters
+- **v0.6.0** - Modern ChatGPT code blocks, MathJax/KaTeX, tables, Gemini refresh
 - **v0.5.0** - Smart file naming, true PDF support, improved duplicate detection
 - **v0.4.0** - Added Google Gemini support, multi-platform architecture
 - **v0.3.0** - Major ChatGPT stability fixes, modern selectors, duplicate prevention

--- a/chatgpt-markdown-exporter.user.js
+++ b/chatgpt-markdown-exporter.user.js
@@ -408,7 +408,9 @@
         }
 
         function tableCellText(cell) {
-            return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+            return normalizeWhitespace(getText(cell))
+                .replace(/\\/g, '\\\\')
+                .replace(/\|/g, '\\|') || ' ';
         }
 
         function tableToMarkdown(table) {
@@ -591,7 +593,10 @@
             }
 
             if (tag === 'code') {
-                const content = getCodeText(node).replace(/`/g, '\\`').trim();
+                const content = getCodeText(node)
+                    .replace(/\\/g, '\\\\')
+                    .replace(/`/g, '\\`')
+                    .trim();
                 return content ? `\`${content}\`` : '';
             }
 
@@ -773,7 +778,7 @@
                 const content = serializeMessageContent(contentRoot, format);
                 const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
 
-                if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+                if (!content || normalizeWhitespace(content).length < minLength) return;
 
                 const hash = contentHash(content);
                 if (seen.has(hash)) return;

--- a/chatgpt-markdown-exporter.user.js
+++ b/chatgpt-markdown-exporter.user.js
@@ -1,12 +1,13 @@
 // ==UserScript==
 // @name         ChatGPT Chat Exporter - Markdown
 // @namespace    https://github.com/rashidazarang/chatgpt-chat-exporter
-// @version      0.6.0
+// @version      0.7.0
 // @description  Export ChatGPT conversations to Markdown format
 // @author       rashidazarang
 // @match        https://chat.openai.com/*
 // @match        https://chatgpt.com/*
 // @match        https://chatgpt.com/c/*
+// @match        https://chat.com/*
 // @grant        none
 // @license      MIT
 // ==/UserScript==
@@ -14,484 +15,1101 @@
 (() => {
     'use strict';
 
-    function formatDate(date = new Date()) {
-        return date.toISOString().split('T')[0];
-    }
+    (function initChatExporterEngine(root, factory) {
+        const engine = factory();
 
-    function cleanMarkdown(text) {
-        return text
-            // Clean up excessive newlines
-            .replace(/\n{3,}/g, '\n\n')
-            // Remove any HTML entities that might have leaked through
-            .replace(/&lt;/g, '<')
-            .replace(/&gt;/g, '>')
-            .replace(/&amp;/g, '&');
-    }
-
-    function getText(element) {
-        return (element?.innerText ?? element?.textContent ?? '').trim();
-    }
-
-    function removeUiElements(clone) {
-        // Remove UI elements that shouldn't be in the export.
-        // Do NOT use [class*="edit"]: it matches CodeMirror's "cm-editor" wrapper
-        // that holds the actual code in modern ChatGPT, and would erase code blocks.
-        clone.querySelectorAll('button, svg, [class*="regenerate"], [data-testid*="copy"], [aria-label*="Copy"], [aria-label*="copy"]').forEach(el => el.remove());
-    }
-
-    function extractCodeBlock(pre) {
-        const codeEl = pre.querySelector('code');
-        const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9_-]+)/);
-        let lang = langMatch ? langMatch[1] : '';
-
-        if (!lang) {
-            const header = pre.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code-block"]');
-            const headerText = getText(header).replace(/\b(copy|code|download)\b/gi, '').trim();
-            if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
-                lang = headerText.toLowerCase();
-            }
-            header?.remove();
+        if (root) {
+            root.ChatExporterEngine = engine;
         }
 
-        const cmContent = pre.querySelector('.cm-content');
-        if (cmContent) {
-            const cmLines = cmContent.querySelectorAll('.cm-line');
-            if (cmLines.length > 0) {
-                return { lang, code: Array.from(cmLines).map(line => line.textContent).join('\n').trim() };
-            }
+        if (typeof module !== 'undefined' && module.exports) {
+            module.exports = engine;
+        }
+    })(typeof globalThis !== 'undefined' ? globalThis : this, function buildChatExporterEngine() {
+        'use strict';
 
-            cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
-            return { lang, code: cmContent.textContent.trim() };
+        const ENGINE_VERSION = '0.7.0-live-engine';
+        const MARKER_PREFIX = '__CHAT_EXPORTER_BLOCK_';
+
+        const PROVIDERS = {
+            chatgpt: {
+                id: 'chatgpt',
+                assistantName: 'ChatGPT',
+                sourceLabel: 'chatgpt.com',
+                defaultTitle: 'Conversation with ChatGPT',
+                genericTitlePattern: /^(chatgpt|new chat|untitled|chat)$/i,
+                messageSelectors: [
+                    'div[data-message-author-role]',
+                    'article[data-testid*="conversation-turn"]',
+                    'div[data-testid="conversation-turn"]',
+                    '.group\\/conversation-turn',
+                    '[data-testid*="message"], [data-message-id], [data-message-author]'
+                ],
+                contentSelectors: [
+                    '.markdown, .prose, [class*="markdown"], [class*="prose"]',
+                    '[data-message-content], [data-testid*="content"]',
+                    '.whitespace-pre-wrap, [class*="whitespace"]'
+                ],
+                titleSelectors: [
+                    'h1:not([class*="hidden"])',
+                    '[class*="conversation-title"]',
+                    '[data-testid*="conversation-title"]'
+                ]
+            },
+            gemini: {
+                id: 'gemini',
+                assistantName: 'Gemini',
+                sourceLabel: 'gemini.google.com',
+                defaultTitle: 'Conversation with Gemini',
+                genericTitlePattern: /^(gemini|new chat|untitled|chat|bard)$/i,
+                messageSelectors: [
+                    'user-query, model-response',
+                    '[data-test-id="conversation-turn"]',
+                    '[data-testid="conversation-turn"]',
+                    '[data-message-author-role]',
+                    '[class*="conversation-turn"]',
+                    '[role="listitem"]'
+                ],
+                contentSelectors: [
+                    'message-content',
+                    '.query-text',
+                    '.response-container',
+                    '.markdown, .prose, [class*="markdown"], [class*="prose"]'
+                ],
+                titleSelectors: [
+                    'h1:not([class*="hidden"])',
+                    '[class*="conversation-title"]',
+                    '[data-testid*="conversation-title"]',
+                    '[aria-label*="conversation"]'
+                ]
+            }
+        };
+
+        function resolveDocument(doc) {
+            if (doc) return doc;
+            if (typeof document !== 'undefined') return document;
+            throw new Error('ChatExporterEngine requires a document.');
         }
 
-        return { lang, code: getText(codeEl || pre) };
-    }
+        function getWindow(doc) {
+            return doc.defaultView || (typeof window !== 'undefined' ? window : null);
+        }
 
-    function processCodeBlocks(clone) {
-        clone.querySelectorAll('pre').forEach(pre => {
-            const { lang, code } = extractCodeBlock(pre);
-            const codeBlock = document.createTextNode(`\n\n\`\`\`${lang}\n${code}\n\`\`\`\n`);
-            pre.parentNode.replaceChild(codeBlock, pre);
-        });
-    }
+        function formatDate(date = new Date()) {
+            return date.toISOString().split('T')[0];
+        }
 
-    function processMath(clone) {
-        const processed = new Set();
+        function sanitizeHtml(value) {
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
 
-        clone.querySelectorAll('annotation[encoding*="tex"]').forEach(annotation => {
-            const tex = annotation.textContent.trim();
-            if (!tex) return;
+        function normalizeWhitespace(value) {
+            return String(value ?? '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+        }
 
-            const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
-            const mathRoot = displayRoot || annotation.closest('.katex, mjx-container, math');
-            if (!mathRoot || processed.has(mathRoot)) return;
+        function getClassName(element) {
+            const className = element?.className;
+            if (!className) return '';
+            if (typeof className === 'string') return className;
+            return className.baseVal || '';
+        }
 
-            processed.add(mathRoot);
-            const wrapper = displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`;
-            mathRoot.replaceWith(document.createTextNode(wrapper));
-        });
+        function queryAll(root, selector) {
+            if (!root || !selector) return [];
 
-        clone.querySelectorAll('script[type^="math/tex"]').forEach(script => {
-            const tex = script.textContent.trim();
-            if (!tex) return;
-            const isDisplay = /mode=display/.test(script.type);
-            script.replaceWith(document.createTextNode(isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
-        });
-    }
+            try {
+                return Array.from(root.querySelectorAll(selector));
+            } catch (error) {
+                console.warn('[Chat Exporter] Selector failed:', selector, error);
+                return [];
+            }
+        }
 
-    function processMedia(clone) {
-        clone.querySelectorAll('img, canvas, video, audio').forEach(el => {
-            const tag = el.tagName.toLowerCase();
-            const alt = el.getAttribute('alt') || el.getAttribute('aria-label') || '';
-            const label = tag === 'img' && alt ? `[Image: ${alt}]` :
-                tag === 'canvas' ? '[Canvas or chart]' :
-                tag === 'video' ? '[Video]' :
-                tag === 'audio' ? '[Audio]' :
-                '[Media]';
-            const placeholder = document.createTextNode(label);
-            el.parentNode.replaceChild(placeholder, el);
-        });
-    }
+        function matches(element, selector) {
+            if (!element || !selector || typeof element.matches !== 'function') return false;
 
-    function processLinks(clone) {
-        clone.querySelectorAll('a[href]').forEach(link => {
-            if (link.closest('pre, code')) return;
+            try {
+                return element.matches(selector);
+            } catch (error) {
+                return false;
+            }
+        }
 
-            const href = (link.href || '').trim();
-            const lowerHref = href.toLowerCase();
-            if (!href || lowerHref.startsWith('javascript:') || lowerHref.startsWith('data:') || lowerHref.startsWith('vbscript:') || href.startsWith('#')) return;
+        function getText(element) {
+            if (!element) return '';
+            const innerText = typeof element.innerText === 'string' ? element.innerText : '';
+            return (innerText || element.textContent || '').replace(/\u00a0/g, ' ').trim();
+        }
 
-            const text = link.textContent.replace(/\s+/g, ' ').trim() || href;
-            const escapedText = text
+        function collectTextWithBreaks(node) {
+            if (!node) return '';
+
+            if (node.nodeType === 3) {
+                return node.nodeValue || '';
+            }
+
+            if (node.nodeType !== 1) {
+                return '';
+            }
+
+            const tag = node.tagName.toLowerCase();
+            if (tag === 'br') return '\n';
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+
+            const before = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+            const after = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+            return before + Array.from(node.childNodes).map(collectTextWithBreaks).join('') + after;
+        }
+
+        function getCodeText(element) {
+            if (!element) return '';
+
+            if (typeof element.innerText === 'string' && element.innerText.trim()) {
+                return element.innerText.replace(/\u00a0/g, ' ').replace(/\n{3,}/g, '\n\n').trimEnd();
+            }
+
+            const clone = element.cloneNode(true);
+            queryAll(clone, 'br').forEach(br => br.replaceWith(clone.ownerDocument.createTextNode('\n')));
+            return collectTextWithBreaks(clone).replace(/\n{3,}/g, '\n\n').trimEnd();
+        }
+
+        function normalizeCodeText(value) {
+            return String(value ?? '')
+                .replace(/\r\n?/g, '\n')
+                .replace(/^\n+/, '')
+                .replace(/\n+$/, '');
+        }
+
+        function createTextNode(reference, text) {
+            return reference.ownerDocument.createTextNode(text);
+        }
+
+        function addReplacement(replacements, html) {
+            const marker = `${MARKER_PREFIX}${replacements.length}__`;
+            replacements.push({ marker, html });
+            return marker;
+        }
+
+        function restoreReplacements(value, replacements) {
+            return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), value);
+        }
+
+        function cleanMarkdown(markdown) {
+            return String(markdown ?? '')
+                .split(/(```[\s\S]*?```)/g)
+                .map(part => part.startsWith('```')
+                    ? part
+                    : part
+                        .replace(/[ \t]+\n/g, '\n')
+                        .replace(/\n[ \t]+/g, '\n')
+                        .replace(/\n{3,}/g, '\n\n')
+                        .replace(/&lt;/g, '<')
+                        .replace(/&gt;/g, '>')
+                        .replace(/&amp;/g, '&'))
+                .join('')
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+        }
+
+        function escapeMarkdownLinkText(value) {
+            return String(value ?? '')
                 .replace(/\\/g, '\\\\')
                 .replace(/([\[\]])/g, '\\$1');
-            const safeHref = href
+        }
+
+        function escapeMarkdownUrl(value) {
+            return String(value ?? '')
                 .replace(/\\/g, '%5C')
                 .replace(/\)/g, '%29');
-            const markdown = `[${escapedText}](${safeHref})`;
-            link.parentNode.replaceChild(document.createTextNode(markdown), link);
-        });
-    }
-
-    function tableCellText(cell) {
-        return getText(cell).replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim() || ' ';
-    }
-
-    function tableToMarkdown(table) {
-        const rows = Array.from(table.querySelectorAll('tr'))
-            .map(row => Array.from(row.children)
-                .filter(cell => ['TH', 'TD'].includes(cell.tagName))
-                .map(tableCellText))
-            .filter(cells => cells.length > 0);
-
-        if (rows.length === 0) return getText(table);
-
-        const width = Math.max(...rows.map(row => row.length));
-        const normalizedRows = rows.map(row => row.concat(Array(Math.max(0, width - row.length)).fill(' ')));
-        const header = normalizedRows[0];
-        const separator = header.map(() => '---');
-        const body = normalizedRows.slice(1);
-        const lines = [
-            `| ${header.join(' | ')} |`,
-            `| ${separator.join(' | ')} |`,
-            ...body.map(row => `| ${row.join(' | ')} |`)
-        ];
-
-        return `\n\n${lines.join('\n')}\n\n`;
-    }
-
-    function processTables(clone) {
-        clone.querySelectorAll('table').forEach(table => {
-            table.replaceWith(document.createTextNode(tableToMarkdown(table)));
-        });
-    }
-
-    function processMessageContent(element) {
-        const clone = element.cloneNode(true);
-
-        removeUiElements(clone);
-        processCodeBlocks(clone);
-        processMath(clone);
-        processMedia(clone);
-        processLinks(clone);
-        processTables(clone);
-
-        // Convert remaining HTML to clean markdown text
-        return cleanMarkdown(getText(clone));
-    }
-
-    function findMessages() {
-        // More specific selectors to avoid nested elements
-        const selectors = [
-            'div[data-message-author-role]', // Modern ChatGPT with clear author role
-            'article[data-testid*="conversation-turn"]', // Conversation turns
-            'div[data-testid="conversation-turn"]', // Specific conversation turn
-            '.group\\/conversation-turn', // Fix for issue #6: More specific selector for conversation turns
-            'div[class*="group"]:not([class*="group"] [class*="group"])', // Top-level groups only
-        ];
-
-        let messages = [];
-        for (const selector of selectors) {
-            messages = document.querySelectorAll(selector);
-            if (messages.length > 0) {
-                console.log(`Using selector: ${selector}, found ${messages.length} messages`);
-                break;
-            }
         }
 
-        if (messages.length === 0) {
-            // Fallback: try to find conversation container and parse its structure
-            const conversationContainer = document.querySelector('[role="main"], main, .conversation, [class*="conversation"]');
-            if (conversationContainer) {
-                // Look for direct children that seem like message containers
-                messages = conversationContainer.querySelectorAll(':scope > div, :scope > article');
-                console.log(`Fallback: found ${messages.length} potential messages in conversation container`);
-            }
+        function isUnsafeHref(href) {
+            const lower = String(href || '').trim().toLowerCase();
+            return !lower ||
+                lower.startsWith('javascript:') ||
+                lower.startsWith('data:') ||
+                lower.startsWith('vbscript:') ||
+                lower.startsWith('#');
         }
 
-        // Filter and validate messages
-        const validMessages = Array.from(messages).filter(msg => {
-            const text = msg.textContent.trim();
-            
-            // Must have substantial content
-            if (text.length < 30) return false;
-            if (text.length > 100000) return false;
-            
-            // Skip elements that are clearly UI components
-            if (msg.querySelector('input[type="text"], textarea')) return false;
-            if (msg.classList.contains('typing') || msg.classList.contains('loading')) return false;
-            
-            // Must contain meaningful content (not just buttons/UI)
-            const meaningfulText = text.replace(/\s+/g, ' ').trim();
-            if (meaningfulText.split(' ').length < 5) return false;
-            
-            return true;
-        });
-
-        // Remove nested messages and consolidate content
-        const consolidatedMessages = [];
-        const usedElements = new Set();
-
-        validMessages.forEach(msg => {
-            if (usedElements.has(msg)) return;
-            
-            // Check if this message is nested within another valid message
-            const isNested = validMessages.some(other => 
-                other !== msg && other.contains(msg) && !usedElements.has(other)
-            );
-            
-            if (!isNested) {
-                consolidatedMessages.push(msg);
-                usedElements.add(msg);
-            }
-        });
-
-        return consolidatedMessages;
-    }
-
-    function identifySender(messageElement, index, allMessages) {
-        // Method 1: Check for data attributes (most reliable)
-        const authorRole = messageElement.getAttribute('data-message-author-role');
-        if (authorRole) {
-            return authorRole === 'user' ? 'You' : 'ChatGPT';
+        function topLevelElements(elements) {
+            return elements.filter(element => !elements.some(other => other !== element && other.contains(element)));
         }
 
-        // Method 2: Look for avatar images with better detection
-        const avatars = messageElement.querySelectorAll('img');
-        for (const avatar of avatars) {
-            const alt = avatar.alt?.toLowerCase() || '';
-            const src = avatar.src?.toLowerCase() || '';
-            const classes = avatar.className?.toLowerCase() || '';
-            
-            // User indicators
-            if (alt.includes('user') || src.includes('user') || classes.includes('user')) {
-                return 'You';
-            }
-            
-            // Assistant indicators
-            if (alt.includes('chatgpt') || alt.includes('assistant') || alt.includes('gpt') || 
-                src.includes('assistant') || src.includes('chatgpt') || classes.includes('assistant')) {
-                return 'ChatGPT';
-            }
+        function removeUiElements(clone) {
+            const uiSelector = [
+                'button',
+                'svg',
+                'style',
+                'script',
+                'textarea',
+                'input',
+                '[contenteditable="true"]',
+                '[class*="regenerate"]',
+                '[class*="copy-button"]',
+                '[data-testid*="copy"]',
+                '[data-test-id*="copy"]',
+                '[aria-label*="Copy"]',
+                '[aria-label*="copy"]',
+                '[aria-label*="More"]',
+                '[aria-label*="more"]'
+            ].join(',');
+
+            queryAll(clone, uiSelector).forEach(element => element.remove());
         }
 
-        // Method 3: Content analysis with better patterns
-        const text = messageElement.textContent.toLowerCase();
-        const textStart = text.substring(0, 200); // Look at beginning of message
-        
-        // Strong ChatGPT indicators
-        if (textStart.match(/^(i understand|i can help|here's|i'll|let me|i'd be happy|certainly|of course)/)) {
-            return 'ChatGPT';
-        }
-        
-        // Strong user indicators  
-        if (textStart.match(/^(can you|please help|how do i|i need|i want|help me|could you)/)) {
-            return 'You';
-        }
+        function detectLanguage(block) {
+            const codeElement = matches(block, 'code') ? block : block.querySelector('code');
+            const sources = [
+                codeElement?.className,
+                block.getAttribute?.('data-language'),
+                block.getAttribute?.('language'),
+                block.getAttribute?.('lang'),
+                codeElement?.getAttribute?.('data-language'),
+                codeElement?.getAttribute?.('language'),
+                codeElement?.getAttribute?.('lang'),
+                block.getAttribute?.('aria-label')
+            ].filter(Boolean).map(String);
 
-        // Method 4: Structural analysis - look at DOM structure
-        const hasCodeBlocks = messageElement.querySelectorAll('pre, code').length > 0;
-        const hasLongText = messageElement.textContent.length > 200;
-        const hasLists = messageElement.querySelectorAll('ul, ol, li').length > 0;
-        
-        // ChatGPT messages tend to be longer and more structured
-        if (hasCodeBlocks && hasLongText && hasLists) {
-            return 'ChatGPT';
-        }
-
-        // Method 5: Position-based fallback with better logic
-        // Try to detect actual alternating pattern by looking at content characteristics
-        if (index > 0 && allMessages[index - 1]) {
-            const prevText = allMessages[index - 1].textContent;
-            const currentText = messageElement.textContent;
-            
-            // If previous was short and current is long, likely user -> assistant
-            if (prevText.length < 100 && currentText.length > 300) {
-                return 'ChatGPT';
-            }
-            
-            // If previous was long and current is short, likely assistant -> user  
-            if (prevText.length > 300 && currentText.length < 100) {
-                return 'You';
-            }
-        }
-
-        // Final fallback
-        return index % 2 === 0 ? 'You' : 'ChatGPT';
-    }
-
-    function extractConversationTitle() {
-        // Try to get actual conversation title
-        const titleSelectors = [
-            'h1:not([class*="hidden"])',
-            '[class*="conversation-title"]',
-            '[data-testid*="conversation-title"]',
-            'title'
-        ];
-
-        for (const selector of titleSelectors) {
-            const element = document.querySelector(selector);
-            if (element && element.textContent.trim()) {
-                const title = element.textContent.trim();
-                // Avoid generic titles
-                if (!['chatgpt', 'new chat', 'untitled', 'chat'].includes(title.toLowerCase())) {
-                    return title;
+            for (const source of sources) {
+                const languageMatch = source.match(/language-([a-zA-Z0-9_+#.-]+)/);
+                if (languageMatch) return languageMatch[1].toLowerCase();
+                if (/^[a-zA-Z0-9_+#.-]{1,24}$/.test(source) && !/^(code|copy|download)$/i.test(source)) {
+                    return source.toLowerCase();
                 }
             }
-        }
 
-        return 'Conversation with ChatGPT';
-    }
-
-    function exportToMarkdown() {
-        const messages = findMessages();
-        
-        if (messages.length === 0) {
-            alert('No messages found. The page structure may have changed.');
-            return;
-        }
-
-        console.log(`Processing ${messages.length} messages...`);
-
-        const lines = [];
-        const title = extractConversationTitle();
-        const date = formatDate();
-        const url = window.location.href;
-
-        lines.push(`# ${title}\n`);
-        lines.push(`**Date:** ${date}`);
-        lines.push(`**Source:** [chat.openai.com](${url})\n`);
-        lines.push(`---\n`);
-
-        // Process messages with better duplicate detection
-        const processedMessages = [];
-        const seenContent = new Set();
-
-        messages.forEach((messageElement, index) => {
-            const sender = identifySender(messageElement, index, messages);
-            const content = processMessageContent(messageElement);
-            
-            // Skip if empty or too short
-            if (!content || content.trim().length < 30) {
-                console.log(`Skipping message ${index}: too short or empty`);
-                return;
+            const header = block.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code"], [data-test-id*="code"], .code-language, .code-lang, [slot="header"]');
+            const headerText = normalizeWhitespace(getText(header)).replace(/\b(copy|code|download)\b/gi, '').trim();
+            if (headerText && headerText.length < 32 && !headerText.includes('\n')) {
+                return headerText.toLowerCase();
             }
 
-            // Create a content hash for duplicate detection
-            const contentHash = content.substring(0, 100).replace(/\s+/g, ' ').trim();
-            if (seenContent.has(contentHash)) {
-                console.log(`Skipping message ${index}: duplicate content`);
-                return;
-            }
-            seenContent.add(contentHash);
+            return '';
+        }
 
-            processedMessages.push({
-                sender,
-                content,
-                originalIndex: index
+        function extractCodeBlock(block) {
+            const clone = block.cloneNode(true);
+            const language = detectLanguage(clone);
+
+            queryAll(clone, 'button, svg, [aria-label*="Copy"], [aria-label*="copy"], [class*="sticky"], [class*="code-header"], [data-testid*="copy"], [data-test-id*="copy"], [slot="header"]').forEach(element => element.remove());
+
+            const cmContent = clone.querySelector('.cm-content');
+            if (cmContent) {
+                const cmLines = queryAll(cmContent, '.cm-line');
+                if (cmLines.length > 0) {
+                    return {
+                        lang: language,
+                        code: normalizeCodeText(cmLines.map(line => line.textContent || '').join('\n'))
+                    };
+                }
+
+                return {
+                    lang: language,
+                    code: normalizeCodeText(getCodeText(cmContent))
+                };
+            }
+
+            const codeElement = matches(clone, 'code') ? clone : clone.querySelector('code');
+            return {
+                lang: language,
+                code: normalizeCodeText(getCodeText(codeElement || clone))
+            };
+        }
+
+        function formatCodeBlock(block, format, replacements) {
+            const { lang, code } = extractCodeBlock(block);
+
+            if (format === 'markdown') {
+                return `\n\n\`\`\`${lang}\n${code}\n\`\`\`\n\n`;
+            }
+
+            const langClass = lang ? ` class="language-${sanitizeHtml(lang)}"` : '';
+            if (format === 'pdf') {
+                const label = lang ? `<div class="code-language">${sanitizeHtml(lang)}</div>` : '';
+                return addReplacement(replacements, `<pre class="code-block">${label}<code>${sanitizeHtml(code)}</code></pre>`);
+            }
+
+            return addReplacement(replacements, `<pre><code${langClass}>${sanitizeHtml(code)}</code></pre>`);
+        }
+
+        function processCodeBlocks(clone, format, replacements) {
+            const blocks = topLevelElements(queryAll(clone, 'pre, code-block, [data-testid*="code-block"], [data-test-id*="code-block"]'));
+
+            blocks.forEach(block => {
+                const replacement = formatCodeBlock(block, format, replacements);
+                block.replaceWith(createTextNode(block, replacement));
             });
-        });
-
-        // Apply sender sequence correction
-        for (let i = 1; i < processedMessages.length; i++) {
-            const current = processedMessages[i];
-            const previous = processedMessages[i - 1];
-            
-            // If we have two consecutive messages from the same sender, try to fix it
-            if (current.sender === previous.sender) {
-                // Use content analysis to determine which should be flipped
-                const currentLength = current.content.length;
-                const previousLength = previous.content.length;
-                
-                // If current message is much longer, it's likely ChatGPT
-                if (currentLength > previousLength * 2 && currentLength > 500) {
-                    current.sender = 'ChatGPT';
-                } else if (previousLength > currentLength * 2 && previousLength > 500) {
-                    previous.sender = 'ChatGPT';
-                    current.sender = 'You';
-                } else {
-                    // Default alternating fix
-                    current.sender = current.sender === 'You' ? 'ChatGPT' : 'You';
-                }
-                
-                console.log(`Fixed consecutive ${previous.sender} messages at positions ${i-1} and ${i}`);
-            }
         }
 
-        // Generate final output
-        processedMessages.forEach(({ sender, content }) => {
-            lines.push(`### **${sender}**\n`);
-            lines.push(content);
-            lines.push('\n---\n');
+        function processMath(clone) {
+            const processed = new Set();
+
+            queryAll(clone, 'annotation').forEach(annotation => {
+                const encoding = (annotation.getAttribute('encoding') || '').toLowerCase();
+                if (!encoding.includes('tex') && !encoding.includes('latex')) return;
+
+                const tex = annotation.textContent.trim();
+                if (!tex) return;
+
+                const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
+                const mathRoot = displayRoot || annotation.closest('.katex') || annotation.closest('mjx-container') || annotation.closest('math');
+                if (!mathRoot || processed.has(mathRoot)) return;
+
+                processed.add(mathRoot);
+                mathRoot.replaceWith(createTextNode(mathRoot, displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+            });
+
+            queryAll(clone, 'script[type^="math/tex"]').forEach(script => {
+                const tex = script.textContent.trim();
+                if (!tex) return;
+                const isDisplay = /mode=display/.test(script.type);
+                script.replaceWith(createTextNode(script, isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+            });
+        }
+
+        function processMedia(clone, format, replacements) {
+            queryAll(clone, 'img, canvas, video, audio').forEach(element => {
+                const tag = element.tagName.toLowerCase();
+                const alt = normalizeWhitespace(element.getAttribute('alt') || element.getAttribute('aria-label') || element.getAttribute('title') || '');
+                const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                    tag === 'img' ? '[Image]' :
+                    tag === 'canvas' ? '[Canvas or chart]' :
+                    tag === 'video' ? '[Video]' :
+                    tag === 'audio' ? '[Audio]' :
+                    '[Media]';
+
+                const replacement = format === 'markdown'
+                    ? label
+                    : addReplacement(replacements, `<span class="media-placeholder">${sanitizeHtml(label)}</span>`);
+                element.replaceWith(createTextNode(element, replacement));
+            });
+        }
+
+        function processLinks(clone, format, replacements) {
+            queryAll(clone, 'a[href]').forEach(link => {
+                if (link.closest('pre, code, code-block')) return;
+
+                const href = String(link.href || link.getAttribute('href') || '').trim();
+                if (isUnsafeHref(href)) return;
+
+                const text = normalizeWhitespace(link.textContent) || href;
+                const replacement = format === 'markdown'
+                    ? `[${escapeMarkdownLinkText(text)}](${escapeMarkdownUrl(href)})`
+                    : addReplacement(replacements, `<a href="${sanitizeHtml(href)}">${sanitizeHtml(text)}</a>`);
+
+                link.replaceWith(createTextNode(link, replacement));
+            });
+        }
+
+        function tableCellText(cell) {
+            return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+        }
+
+        function tableToMarkdown(table) {
+            const rows = queryAll(table, 'tr')
+                .map(row => Array.from(row.children)
+                    .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                    .map(tableCellText))
+                .filter(row => row.length > 0);
+
+            if (rows.length === 0) return normalizeWhitespace(getText(table));
+
+            const width = Math.max(...rows.map(row => row.length));
+            const normalizedRows = rows.map(row => row.concat(Array(Math.max(0, width - row.length)).fill(' ')));
+            const header = normalizedRows[0];
+            const separator = header.map(() => '---');
+            const body = normalizedRows.slice(1);
+
+            return [
+                `| ${header.join(' | ')} |`,
+                `| ${separator.join(' | ')} |`,
+                ...body.map(row => `| ${row.join(' | ')} |`)
+            ].join('\n');
+        }
+
+        function tableToHtml(table) {
+            const rows = queryAll(table, 'tr')
+                .map(row => Array.from(row.children)
+                    .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                    .map(cell => ({
+                        tag: cell.tagName.toLowerCase(),
+                        text: normalizeWhitespace(getText(cell))
+                    })))
+                .filter(row => row.length > 0);
+
+            if (rows.length === 0) return sanitizeHtml(getText(table));
+
+            return `<table>${rows.map(row => {
+                const cells = row.map(cell => `<${cell.tag}>${sanitizeHtml(cell.text)}</${cell.tag}>`).join('');
+                return `<tr>${cells}</tr>`;
+            }).join('')}</table>`;
+        }
+
+        function processTables(clone, format, replacements) {
+            topLevelElements(queryAll(clone, 'table')).forEach(table => {
+                const replacement = format === 'markdown'
+                    ? `\n\n${tableToMarkdown(table)}\n\n`
+                    : addReplacement(replacements, tableToHtml(table));
+                table.replaceWith(createTextNode(table, replacement));
+            });
+        }
+
+        function cardSignal(element) {
+            const pieces = [
+                element.tagName,
+                getClassName(element),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id'),
+                element.getAttribute('aria-label'),
+                element.getAttribute('role')
+            ].filter(Boolean).join(' ').toLowerCase();
+
+            if (/\b(artifact|canvas-preview|generated-file|download-card|attachment|file-card)\b/.test(pieces)) {
+                return pieces.includes('artifact') || pieces.includes('canvas-preview') ? 'Artifact' : 'File';
+            }
+
+            if (/(^|[\s_-])(attachment|file)([\s_-]|$)/.test(pieces)) {
+                return 'File';
+            }
+
+            return '';
+        }
+
+        function cardLabel(element) {
+            const candidates = [
+                element.getAttribute('aria-label'),
+                element.getAttribute('title'),
+                element.getAttribute('download'),
+                element.getAttribute('data-filename'),
+                getText(element)
+            ].filter(Boolean).map(normalizeWhitespace);
+
+            const label = candidates.find(value => value && value.length <= 180) || '';
+            return label
+                .replace(/\b(open|download|preview|file|attachment|artifact)\b/gi, ' ')
+                .replace(/\s+/g, ' ')
+                .trim();
+        }
+
+        function processCards(clone, format, replacements) {
+            const cards = topLevelElements(Array.from(clone.querySelectorAll('*')).filter(element => {
+                const kind = cardSignal(element);
+                if (!kind) return false;
+                if (matches(element, '[data-message-author-role], user-query, model-response')) return false;
+                if (element.closest('pre, code, code-block, table')) return false;
+                if (element.querySelector('pre, code-block, table, user-query, model-response')) return false;
+
+                const text = normalizeWhitespace(getText(element));
+                const label = cardLabel(element);
+                return Boolean(label || text) && text.length <= 240;
+            }));
+
+            cards.forEach(card => {
+                const kind = cardSignal(card);
+                const label = cardLabel(card);
+                const text = label ? `[${kind}: ${label}]` : `[${kind}]`;
+                const replacement = format === 'markdown'
+                    ? text
+                    : addReplacement(replacements, `<span class="card-placeholder">${sanitizeHtml(text)}</span>`);
+                card.replaceWith(createTextNode(card, replacement));
+            });
+        }
+
+        function serializeMarkdownChildren(element, context = {}) {
+            return Array.from(element.childNodes).map((node, index) => serializeMarkdownNode(node, {
+                ...context,
+                index
+            })).join('');
+        }
+
+        function serializeMarkdownNode(node, context = {}) {
+            if (node.nodeType === 3) {
+                const value = node.nodeValue || '';
+                if (value.includes('```') || value.includes('| ---') || value.includes(MARKER_PREFIX) || value.match(/^\s*\[[^\]]+\]/)) {
+                    return value;
+                }
+                return value.replace(/[ \t\r\n]+/g, ' ');
+            }
+
+            if (node.nodeType !== 1) return '';
+
+            const tag = node.tagName.toLowerCase();
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+            if (tag === 'br') return '\n';
+
+            if (/^h[1-6]$/.test(tag)) {
+                const level = Number(tag.slice(1));
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${'#'.repeat(level)} ${content}\n\n` : '';
+            }
+
+            if (tag === 'p') {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${content}\n\n` : '';
+            }
+
+            if (tag === 'blockquote') {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${content.split('\n').map(line => `> ${line.trim()}`).join('\n')}\n\n` : '';
+            }
+
+            if (tag === 'ul' || tag === 'ol') {
+                const children = Array.from(node.children).filter(child => child.tagName && child.tagName.toLowerCase() === 'li');
+                return `\n${children.map((child, index) => serializeMarkdownNode(child, {
+                    ...context,
+                    listType: tag,
+                    index,
+                    depth: (context.depth || 0)
+                })).join('')}\n`;
+            }
+
+            if (tag === 'li') {
+                const depth = context.depth || 0;
+                const marker = context.listType === 'ol' ? `${(context.index || 0) + 1}. ` : '- ';
+                const indent = '  '.repeat(depth);
+                const content = serializeMarkdownChildren(node, {
+                    ...context,
+                    depth: depth + 1
+                }).trim();
+                return content ? `${indent}${marker}${content.replace(/\n+/g, `\n${indent}  `)}\n` : '';
+            }
+
+            if (['strong', 'b'].includes(tag)) {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `**${content}**` : '';
+            }
+
+            if (['em', 'i'].includes(tag)) {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `*${content}*` : '';
+            }
+
+            if (tag === 'code') {
+                const content = getCodeText(node).replace(/`/g, '\\`').trim();
+                return content ? `\`${content}\`` : '';
+            }
+
+            const content = serializeMarkdownChildren(node, context);
+            if (['div', 'section', 'article', 'main', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+                return content;
+            }
+
+            return content;
+        }
+
+        function serializeHtmlChildren(element, replacements) {
+            return Array.from(element.childNodes).map(node => serializeHtmlNode(node, replacements)).join('');
+        }
+
+        function serializeHtmlNode(node, replacements) {
+            if (node.nodeType === 3) {
+                return sanitizeHtml(node.nodeValue || '');
+            }
+
+            if (node.nodeType !== 1) return '';
+
+            const tag = node.tagName.toLowerCase();
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+            if (tag === 'br') return '<br>';
+
+            const content = serializeHtmlChildren(node, replacements);
+            const blockTags = new Set(['p', 'ul', 'ol', 'li', 'blockquote', 'strong', 'b', 'em', 'i']);
+
+            if (/^h[1-6]$/.test(tag)) {
+                return `<${tag}>${content}</${tag}>`;
+            }
+
+            if (blockTags.has(tag)) {
+                const safeTag = tag === 'b' ? 'strong' : tag === 'i' ? 'em' : tag;
+                return `<${safeTag}>${content}</${safeTag}>`;
+            }
+
+            if (tag === 'code') {
+                return `<code>${sanitizeHtml(getCodeText(node).trim())}</code>`;
+            }
+
+            if (['div', 'section', 'article', 'main', 'span', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+                return content;
+            }
+
+            return content;
+        }
+
+        function serializeMessageContent(element, format) {
+            const clone = element.cloneNode(true);
+            const replacements = [];
+
+            removeUiElements(clone);
+            processCards(clone, format, replacements);
+            processCodeBlocks(clone, format, replacements);
+            processMath(clone);
+            processMedia(clone, format, replacements);
+            processLinks(clone, format, replacements);
+            processTables(clone, format, replacements);
+
+            if (format === 'markdown') {
+                return cleanMarkdown(serializeMarkdownChildren(clone));
+            }
+
+            const html = serializeHtmlChildren(clone, replacements)
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+            return restoreReplacements(html, replacements);
+        }
+
+        function detectProvider(doc) {
+            const url = doc.defaultView?.location?.href || '';
+            if (/gemini\.google\.com/i.test(url) || doc.querySelector('user-query, model-response')) return 'gemini';
+            return 'chatgpt';
+        }
+
+        function providerFor(providerName, doc) {
+            const id = providerName || detectProvider(doc);
+            return PROVIDERS[id] || PROVIDERS.chatgpt;
+        }
+
+        function meaningfulScore(element) {
+            const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+            return normalizeWhitespace(element.textContent).length + richCount * 200;
+        }
+
+        function isValidMessage(element) {
+            const text = normalizeWhitespace(element.textContent);
+            const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+
+            if (text.length < 5 && richCount === 0) return false;
+            if (text.length > 200000) return false;
+            if (matches(element, 'nav, aside, header, footer, form, menu')) return false;
+            if (element.querySelector('textarea, input[type="text"], [contenteditable="true"]') && !element.hasAttribute('data-message-author-role')) return false;
+            if (getClassName(element).match(/\b(typing|loading|spinner)\b/i)) return false;
+
+            return true;
+        }
+
+        function findMessages(doc, provider) {
+            for (const selector of provider.messageSelectors) {
+                const messages = topLevelElements(queryAll(doc, selector)).filter(isValidMessage);
+                if (messages.length > 0) {
+                    console.log(`[Chat Exporter] ${provider.id}: using selector "${selector}" (${messages.length} messages)`);
+                    return messages;
+                }
+            }
+
+            const container = doc.querySelector('[role="main"], main, [class*="conversation"], [class*="chat"]');
+            if (!container) return [];
+
+            return topLevelElements(queryAll(container, ':scope > article, :scope > section, :scope > div')).filter(isValidMessage);
+        }
+
+        function selectContentRoot(messageElement, provider) {
+            const candidates = [messageElement];
+
+            provider.contentSelectors.forEach(selector => {
+                if (matches(messageElement, selector)) candidates.push(messageElement);
+                candidates.push(...queryAll(messageElement, selector));
+            });
+
+            return candidates
+                .filter(Boolean)
+                .sort((a, b) => meaningfulScore(b) - meaningfulScore(a))[0] || messageElement;
+        }
+
+        function identifySender(element, index, provider) {
+            const tag = element.tagName.toLowerCase();
+            if (tag === 'user-query') return { sender: 'You', reliable: true };
+            if (tag === 'model-response') return { sender: provider.assistantName, reliable: true };
+
+            const role = element.getAttribute('data-message-author-role') || element.getAttribute('data-author') || element.getAttribute('data-sender');
+            if (role) {
+                const normalizedRole = role.toLowerCase();
+                if (normalizedRole === 'user') return { sender: 'You', reliable: true };
+                if (['assistant', 'model', 'bot', 'chatgpt', 'gemini'].includes(normalizedRole)) {
+                    return { sender: provider.assistantName, reliable: true };
+                }
+            }
+
+            const classAndAttrs = [
+                getClassName(element),
+                element.getAttribute('aria-label'),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id')
+            ].filter(Boolean).join(' ').toLowerCase();
+
+            if (classAndAttrs.match(/\b(user|human|query)\b/)) return { sender: 'You', reliable: false };
+            if (classAndAttrs.match(/\b(assistant|model|response|chatgpt|gemini|bard)\b/)) return { sender: provider.assistantName, reliable: false };
+
+            const textStart = normalizeWhitespace(element.textContent).slice(0, 220).toLowerCase();
+            if (/^(i understand|i can help|here's|i'll|let me|i'd be happy|certainly|of course|absolutely)/.test(textStart)) {
+                return { sender: provider.assistantName, reliable: false };
+            }
+
+            if (/^(can you|please help|how do i|i need|i want|help me|could you|explain|what is)/.test(textStart)) {
+                return { sender: 'You', reliable: false };
+            }
+
+            return { sender: index % 2 === 0 ? 'You' : provider.assistantName, reliable: false };
+        }
+
+        function contentHash(content) {
+            return normalizeWhitespace(String(content || '').replace(/<[^>]+>/g, ' ')).slice(0, 160);
+        }
+
+        function extractConversation(options = {}) {
+            const doc = resolveDocument(options.document);
+            const provider = providerFor(options.provider, doc);
+            const format = options.format || 'markdown';
+            const rawMessages = findMessages(doc, provider);
+            const seen = new Set();
+            const messages = [];
+
+            rawMessages.forEach((messageElement, index) => {
+                const contentRoot = selectContentRoot(messageElement, provider);
+                const content = serializeMessageContent(contentRoot, format);
+                const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
+
+                if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+
+                const hash = contentHash(content);
+                if (seen.has(hash)) return;
+                seen.add(hash);
+
+                const sender = identifySender(messageElement, index, provider);
+                messages.push({
+                    sender: sender.sender,
+                    senderType: sender.sender === 'You' ? 'user' : 'assistant',
+                    reliableSender: sender.reliable,
+                    content,
+                    index
+                });
+            });
+
+            return {
+                version: ENGINE_VERSION,
+                provider: provider.id,
+                providerLabel: provider.assistantName,
+                sourceLabel: provider.sourceLabel,
+                title: extractConversationTitle(doc, provider),
+                sourceUrl: doc.defaultView?.location?.href || '',
+                date: formatDate(options.date || new Date()),
+                messages
+            };
+        }
+
+        function extractConversationTitle(doc, provider) {
+            for (const selector of provider.titleSelectors) {
+                const element = doc.querySelector(selector);
+                const title = normalizeWhitespace(element?.textContent);
+                if (title && !provider.genericTitlePattern.test(title)) return title;
+            }
+
+            const docTitle = normalizeWhitespace(doc.title);
+            if (docTitle && !provider.genericTitlePattern.test(docTitle)) return docTitle;
+
+            return provider.defaultTitle;
+        }
+
+        function renderMarkdown(conversation) {
+            const lines = [
+                `# ${conversation.title}\n`,
+                `**Date:** ${conversation.date}`,
+                `**Source:** [${conversation.sourceLabel}](${conversation.sourceUrl})\n`,
+                '---\n'
+            ];
+
+            conversation.messages.forEach(message => {
+                lines.push(`### **${message.sender}**\n`, message.content, '\n---\n');
+            });
+
+            return `${lines.join('\n').trim()}\n`;
+        }
+
+        function renderHtmlDocument(conversation, options = {}) {
+            const isPdf = options.format === 'pdf';
+            const source = sanitizeHtml(conversation.sourceUrl);
+            const title = sanitizeHtml(conversation.title);
+            const messages = conversation.messages.map(message => {
+                const senderClass = message.senderType === 'user' ? 'user' : 'assistant';
+                return `
+            <div class="message ${senderClass}">
+                <div class="sender">${sanitizeHtml(message.sender)}</div>
+                <div class="content">${message.content}</div>
+            </div>`;
+            }).join('');
+
+            const pdfInstructions = isPdf ? `
+        <div class="instructions no-print">
+            <h3>Convert to PDF</h3>
+            <ol>
+                <li>Press Ctrl+P on Windows/Linux or Cmd+P on Mac.</li>
+                <li>Set Destination to Save as PDF.</li>
+                <li>Choose your preferred page size.</li>
+                <li>Click Save.</li>
+            </ol>
+            <p><em>This instruction box will not appear in the PDF.</em></p>
+        </div>` : '';
+
+            return `<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <title>${title} - ${conversation.date}</title>
+        <style>
+            @media print {
+                body { margin: 0; }
+                .no-print { display: none; }
+                .message { page-break-inside: avoid; }
+            }
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+                max-width: 840px;
+                margin: auto;
+                padding: 2rem;
+                background: #fff;
+                color: #333;
+                line-height: 1.6;
+            }
+            .header {
+                text-align: center;
+                margin-bottom: 2rem;
+                padding-bottom: 1rem;
+                border-bottom: 2px solid #eee;
+            }
+            .metadata {
+                color: #666;
+                font-size: 0.9rem;
+            }
+            .message {
+                margin-bottom: 1.5rem;
+                padding: 1rem;
+                border-radius: 8px;
+                background: #f8f9fa;
+            }
+            .message.user {
+                background: #eaf4ff;
+            }
+            .sender {
+                font-weight: 700;
+                color: #2c3e50;
+                margin-bottom: 0.5rem;
+            }
+            .content {
+                white-space: pre-wrap;
+                overflow-wrap: anywhere;
+            }
+            pre {
+                background: #f4f4f4;
+                padding: 1rem;
+                border-radius: 4px;
+                overflow-x: auto;
+                border-left: 4px solid #007acc;
+            }
+            .code-block {
+                background: #282c34;
+                color: #abb2bf;
+                border-left: 0;
+            }
+            .code-block code {
+                white-space: pre;
+            }
+            .code-language {
+                color: #d7dae0;
+                font-size: 12px;
+                margin-bottom: 8px;
+                text-transform: uppercase;
+            }
+            code {
+                font-family: Consolas, Monaco, "Courier New", monospace;
+                font-size: 0.92rem;
+            }
+            table {
+                width: 100%;
+                border-collapse: collapse;
+                margin: 1rem 0;
+            }
+            th, td {
+                border: 1px solid #d9dde3;
+                padding: 0.5rem;
+                text-align: left;
+                vertical-align: top;
+            }
+            th {
+                background: #eef2f7;
+            }
+            .instructions {
+                background: #fff8dc;
+                border: 1px solid #e3c565;
+                border-radius: 8px;
+                padding: 1rem;
+                margin-bottom: 1.5rem;
+            }
+        </style>
+    </head>
+    <body>
+        ${pdfInstructions}
+        <div class="header">
+            <h1>${title}</h1>
+            <div class="metadata">
+                <div><strong>Date:</strong> ${sanitizeHtml(conversation.date)}</div>
+                <div><strong>Source:</strong> <a href="${source}">${sanitizeHtml(conversation.sourceLabel)}</a></div>
+                <div><strong>Messages:</strong> ${conversation.messages.length}</div>
+            </div>
+        </div>
+        <div class="conversation">${messages}
+        </div>
+    </body>
+    </html>`;
+        }
+
+        function render(conversation, format) {
+            if (format === 'markdown') return renderMarkdown(conversation);
+            if (format === 'pdf') return renderHtmlDocument(conversation, { format: 'pdf' });
+            if (format === 'html') return renderHtmlDocument(conversation, { format: 'html' });
+            throw new Error(`Unsupported export format: ${format}`);
+        }
+
+        function filenameFor(conversation, format, doc) {
+            const safeTitle = normalizeWhitespace(doc.title || conversation.title)
+                .replace(/[<>:"/\\|?*]/g, '')
+                .slice(0, 120);
+
+            if (format === 'markdown') {
+                return safeTitle ? `${safeTitle} (${conversation.date}).md` : `${conversation.providerLabel}_Conversation_${conversation.date}.md`;
+            }
+
+            if (format === 'pdf') {
+                return safeTitle ? `${safeTitle} (${conversation.date}) - PrintToPDF.html` : `${conversation.providerLabel}_Conversation_${conversation.date}_PrintToPDF.html`;
+            }
+
+            return safeTitle ? `${safeTitle} (${conversation.date}).html` : `${conversation.providerLabel}_Conversation_${conversation.date}.html`;
+        }
+
+        function mimeFor(format) {
+            return format === 'markdown' ? 'text/markdown' : 'text/html';
+        }
+
+        function downloadFile(doc, content, filename, mimeType) {
+            const win = getWindow(doc);
+            const BlobCtor = win?.Blob || Blob;
+            const urlApi = win?.URL || URL;
+            const blob = new BlobCtor([content], { type: mimeType });
+            const url = urlApi.createObjectURL(blob);
+            const anchor = doc.createElement('a');
+
+            anchor.href = url;
+            anchor.download = filename;
+            doc.body.appendChild(anchor);
+            anchor.click();
+            doc.body.removeChild(anchor);
+            urlApi.revokeObjectURL(url);
+        }
+
+        function exportConversation(options = {}) {
+            const doc = resolveDocument(options.document);
+            const format = options.format || 'markdown';
+            const conversation = extractConversation({
+                ...options,
+                document: doc,
+                format
+            });
+
+            if (conversation.messages.length === 0) {
+                const message = 'No messages found. The page structure may have changed.';
+                const win = getWindow(doc);
+                if (typeof win?.alert === 'function') win.alert(message);
+                console.warn(`[Chat Exporter] ${message}`);
+                return { conversation, content: '' };
+            }
+
+            const content = render(conversation, format);
+            const filename = options.filename || filenameFor(conversation, format, doc);
+
+            if (options.download !== false) {
+                downloadFile(doc, content, filename, mimeFor(format));
+                console.log(`[Chat Exporter] Exported ${conversation.messages.length} messages to ${filename}`);
+            }
+
+            return { conversation, content, filename };
+        }
+
+        return {
+            version: ENGINE_VERSION,
+            providers: PROVIDERS,
+            detectProvider,
+            extractConversation,
+            exportConversation,
+            serializers: {
+                markdown: renderMarkdown,
+                html: conversation => renderHtmlDocument(conversation, { format: 'html' }),
+                pdf: conversation => renderHtmlDocument(conversation, { format: 'pdf' })
+            },
+            internals: {
+                serializeMessageContent,
+                extractCodeBlock,
+                tableToMarkdown,
+                tableToHtml
+            }
+        };
+    });
+
+    function runExport() {
+        globalThis.ChatExporterEngine.exportConversation({
+            provider: 'chatgpt',
+            format: 'markdown'
         });
-
-        // Create and download file
-        const markdownContent = lines.join('\n');
-        const blob = new Blob([markdownContent], { type: 'text/markdown' });
-        const url2 = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url2;
-        // Use document title for better file naming (Issue #12)
-        const safeTitle = document.title.replace(/[<>:"/\\|?*]/g, '').replace(/\s+/g, ' ').trim();
-        a.download = safeTitle ? `${safeTitle} (${date}).md` : `ChatGPT_Conversation_${date}.md`;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url2);
-
-        console.log(`Export completed: ${processedMessages.length} messages exported`);
     }
 
-    // Add export button to the page
     function addExportButton() {
-        // Check if button already exists
         if (document.querySelector('#chatgpt-export-markdown-btn')) return;
 
         const button = document.createElement('button');
         button.id = 'chatgpt-export-markdown-btn';
-        button.textContent = 'Export as Markdown';
-        button.style.cssText = `
-            position: fixed;
-            bottom: 20px;
-            right: 20px;
-            padding: 10px 20px;
-            background-color: #10a37f;
-            color: white;
-            border: none;
-            border-radius: 5px;
-            cursor: pointer;
-            z-index: 10000;
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            font-size: 14px;
-            font-weight: 500;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        `;
-        
-        button.addEventListener('click', exportToMarkdown);
+        button.textContent = 'Export Markdown';
+        button.style.cssText = [
+            'position: fixed',
+            'bottom: 20px',
+            'right: 20px',
+            'padding: 10px 16px',
+            'background-color: #10a37f',
+            'color: white',
+            'border: none',
+            'border-radius: 5px',
+            'cursor: pointer',
+            'z-index: 10000',
+            'font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+            'font-size: 14px',
+            'font-weight: 600',
+            'box-shadow: 0 2px 4px rgba(0,0,0,0.2)'
+        ].join(';');
+
+        button.addEventListener('click', runExport);
         button.addEventListener('mouseenter', () => {
             button.style.backgroundColor = '#0d8f6e';
         });
         button.addEventListener('mouseleave', () => {
             button.style.backgroundColor = '#10a37f';
         });
-        
+
         document.body.appendChild(button);
     }
 
-    // Wait for page to load
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', addExportButton);
-    } else {
-        // Add button after a short delay to ensure page is fully loaded
-        setTimeout(addExportButton, 1000);
+    function installButton() {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => setTimeout(addExportButton, 1000), { once: true });
+        } else {
+            setTimeout(addExportButton, 1000);
+        }
+
+        const observer = new MutationObserver(() => {
+            if (!document.querySelector('#chatgpt-export-markdown-btn')) addExportButton();
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
     }
 
-    // Re-add button if navigation changes (for SPAs)
-    const observer = new MutationObserver(() => {
-        if (!document.querySelector('#chatgpt-export-markdown-btn')) {
-            addExportButton();
-        }
-    });
-    
-    observer.observe(document.body, { childList: true, subtree: true });
+    installButton();
 })();

--- a/chatgpt-pdf-exporter.user.js
+++ b/chatgpt-pdf-exporter.user.js
@@ -408,7 +408,9 @@
         }
 
         function tableCellText(cell) {
-            return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+            return normalizeWhitespace(getText(cell))
+                .replace(/\\/g, '\\\\')
+                .replace(/\|/g, '\\|') || ' ';
         }
 
         function tableToMarkdown(table) {
@@ -591,7 +593,10 @@
             }
 
             if (tag === 'code') {
-                const content = getCodeText(node).replace(/`/g, '\\`').trim();
+                const content = getCodeText(node)
+                    .replace(/\\/g, '\\\\')
+                    .replace(/`/g, '\\`')
+                    .trim();
                 return content ? `\`${content}\`` : '';
             }
 
@@ -773,7 +778,7 @@
                 const content = serializeMessageContent(contentRoot, format);
                 const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
 
-                if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+                if (!content || normalizeWhitespace(content).length < minLength) return;
 
                 const hash = contentHash(content);
                 if (seen.has(hash)) return;

--- a/chatgpt-pdf-exporter.user.js
+++ b/chatgpt-pdf-exporter.user.js
@@ -1,536 +1,1115 @@
 // ==UserScript==
 // @name         ChatGPT Chat Exporter - PDF
 // @namespace    https://github.com/rashidazarang/chatgpt-chat-exporter
-// @version      0.6.0
+// @version      0.7.0
 // @description  Export ChatGPT conversations to PDF-ready HTML format
 // @author       rashidazarang
 // @match        https://chat.openai.com/*
 // @match        https://chatgpt.com/*
 // @match        https://chatgpt.com/c/*
+// @match        https://chat.com/*
 // @grant        none
 // @license      MIT
 // ==/UserScript==
 
 (() => {
     'use strict';
-    
-    function formatDate(date = new Date()) {
-        return date.toISOString().split('T')[0];
-    }
 
-    function cleanText(text) {
-        return text
-            .replace(/&/g, '&amp;')  // Replace & first to avoid double-escaping
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;')
-            .trim();
-    }
+    (function initChatExporterEngine(root, factory) {
+        const engine = factory();
 
-    function getText(element) {
-        return (element?.innerText ?? element?.textContent ?? '').trim();
-    }
-
-    function extractCodeBlock(pre) {
-        const codeEl = pre.querySelector('code');
-        const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9_-]+)/);
-        let lang = langMatch ? langMatch[1] : '';
-
-        if (!lang) {
-            const header = pre.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code-block"]');
-            const headerText = getText(header).replace(/\b(copy|code|download)\b/gi, '').trim();
-            if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
-                lang = headerText.toLowerCase();
-            }
-            header?.remove();
+        if (root) {
+            root.ChatExporterEngine = engine;
         }
 
-        const cmContent = pre.querySelector('.cm-content');
-        if (cmContent) {
-            const cmLines = cmContent.querySelectorAll('.cm-line');
-            if (cmLines.length > 0) {
-                return { lang, code: Array.from(cmLines).map(line => line.textContent).join('\n').trim() };
-            }
+        if (typeof module !== 'undefined' && module.exports) {
+            module.exports = engine;
+        }
+    })(typeof globalThis !== 'undefined' ? globalThis : this, function buildChatExporterEngine() {
+        'use strict';
 
-            cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
-            return { lang, code: cmContent.textContent.trim() };
+        const ENGINE_VERSION = '0.7.0-live-engine';
+        const MARKER_PREFIX = '__CHAT_EXPORTER_BLOCK_';
+
+        const PROVIDERS = {
+            chatgpt: {
+                id: 'chatgpt',
+                assistantName: 'ChatGPT',
+                sourceLabel: 'chatgpt.com',
+                defaultTitle: 'Conversation with ChatGPT',
+                genericTitlePattern: /^(chatgpt|new chat|untitled|chat)$/i,
+                messageSelectors: [
+                    'div[data-message-author-role]',
+                    'article[data-testid*="conversation-turn"]',
+                    'div[data-testid="conversation-turn"]',
+                    '.group\\/conversation-turn',
+                    '[data-testid*="message"], [data-message-id], [data-message-author]'
+                ],
+                contentSelectors: [
+                    '.markdown, .prose, [class*="markdown"], [class*="prose"]',
+                    '[data-message-content], [data-testid*="content"]',
+                    '.whitespace-pre-wrap, [class*="whitespace"]'
+                ],
+                titleSelectors: [
+                    'h1:not([class*="hidden"])',
+                    '[class*="conversation-title"]',
+                    '[data-testid*="conversation-title"]'
+                ]
+            },
+            gemini: {
+                id: 'gemini',
+                assistantName: 'Gemini',
+                sourceLabel: 'gemini.google.com',
+                defaultTitle: 'Conversation with Gemini',
+                genericTitlePattern: /^(gemini|new chat|untitled|chat|bard)$/i,
+                messageSelectors: [
+                    'user-query, model-response',
+                    '[data-test-id="conversation-turn"]',
+                    '[data-testid="conversation-turn"]',
+                    '[data-message-author-role]',
+                    '[class*="conversation-turn"]',
+                    '[role="listitem"]'
+                ],
+                contentSelectors: [
+                    'message-content',
+                    '.query-text',
+                    '.response-container',
+                    '.markdown, .prose, [class*="markdown"], [class*="prose"]'
+                ],
+                titleSelectors: [
+                    'h1:not([class*="hidden"])',
+                    '[class*="conversation-title"]',
+                    '[data-testid*="conversation-title"]',
+                    '[aria-label*="conversation"]'
+                ]
+            }
+        };
+
+        function resolveDocument(doc) {
+            if (doc) return doc;
+            if (typeof document !== 'undefined') return document;
+            throw new Error('ChatExporterEngine requires a document.');
         }
 
-        return { lang, code: getText(codeEl || pre) };
-    }
+        function getWindow(doc) {
+            return doc.defaultView || (typeof window !== 'undefined' ? window : null);
+        }
 
-    function addReplacement(replacements, html) {
-        const marker = `EXPORTER_BLOCK_${replacements.length}`;
-        replacements.push({ marker, html });
-        return marker;
-    }
+        function formatDate(date = new Date()) {
+            return date.toISOString().split('T')[0];
+        }
 
-    function processCodeBlocks(clone, replacements) {
-        clone.querySelectorAll('pre').forEach(pre => {
-            const { lang, code } = extractCodeBlock(pre);
-            const label = lang ? `<div class="code-language">${cleanText(lang)}</div>` : '';
-            const html = `<pre class="code-block">${label}<code>${cleanText(code)}</code></pre>`;
-            pre.replaceWith(document.createTextNode(addReplacement(replacements, html)));
-        });
-    }
+        function sanitizeHtml(value) {
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
 
-    function processMath(clone) {
-        const processed = new Set();
+        function normalizeWhitespace(value) {
+            return String(value ?? '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+        }
 
-        clone.querySelectorAll('annotation[encoding*="tex"]').forEach(annotation => {
-            const tex = annotation.textContent.trim();
-            if (!tex) return;
+        function getClassName(element) {
+            const className = element?.className;
+            if (!className) return '';
+            if (typeof className === 'string') return className;
+            return className.baseVal || '';
+        }
 
-            const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
-            const mathRoot = displayRoot || annotation.closest('.katex, mjx-container, math');
-            if (!mathRoot || processed.has(mathRoot)) return;
+        function queryAll(root, selector) {
+            if (!root || !selector) return [];
 
-            processed.add(mathRoot);
-            mathRoot.replaceWith(document.createTextNode(displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
-        });
-
-        clone.querySelectorAll('script[type^="math/tex"]').forEach(script => {
-            const tex = script.textContent.trim();
-            if (!tex) return;
-            const isDisplay = /mode=display/.test(script.type);
-            script.replaceWith(document.createTextNode(isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
-        });
-    }
-
-    function processMedia(clone) {
-        clone.querySelectorAll('img, canvas, video, audio').forEach(el => {
-            const tag = el.tagName.toLowerCase();
-            const alt = el.getAttribute('alt') || el.getAttribute('aria-label') || '';
-            const label = tag === 'img' && alt ? `[Image: ${alt}]` :
-                tag === 'canvas' ? '[Canvas or chart]' :
-                tag === 'video' ? '[Video]' :
-                tag === 'audio' ? '[Audio]' :
-                '[Media]';
-            el.replaceWith(document.createTextNode(label));
-        });
-    }
-
-    function processLinks(clone, replacements) {
-        clone.querySelectorAll('a[href]').forEach(link => {
-            if (link.closest('pre, code')) return;
-
-            const href = (link.href || '').trim();
-            const lowerHref = href.toLowerCase();
-            if (!href || lowerHref.startsWith('javascript:') || lowerHref.startsWith('data:') || lowerHref.startsWith('vbscript:') || href.startsWith('#')) return;
-
-            const text = link.textContent.replace(/\s+/g, ' ').trim() || href;
-            const html = `<a href="${cleanText(href)}">${cleanText(text)}</a>`;
-            link.replaceWith(document.createTextNode(addReplacement(replacements, html)));
-        });
-    }
-
-    function tableToHtml(table) {
-        const rows = Array.from(table.querySelectorAll('tr'))
-            .map(row => Array.from(row.children)
-                .filter(cell => ['TH', 'TD'].includes(cell.tagName))
-                .map(cell => ({ tag: cell.tagName.toLowerCase(), text: getText(cell).replace(/\s+/g, ' ') })))
-            .filter(cells => cells.length > 0);
-
-        if (rows.length === 0) return cleanText(getText(table));
-
-        const renderedRows = rows.map(cells => {
-            const renderedCells = cells.map(cell => `<${cell.tag}>${cleanText(cell.text)}</${cell.tag}>`).join('');
-            return `<tr>${renderedCells}</tr>`;
-        }).join('');
-
-        return `<table>${renderedRows}</table>`;
-    }
-
-    function processTables(clone, replacements) {
-        clone.querySelectorAll('table').forEach(table => {
-            table.replaceWith(document.createTextNode(addReplacement(replacements, tableToHtml(table))));
-        });
-    }
-
-    function restoreReplacements(html, replacements) {
-        return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), html);
-    }
-
-    function findMessages() {
-        const selectors = [
-            'div[data-message-author-role]',
-            'article[data-testid*="conversation-turn"]',
-            'div[data-testid="conversation-turn"]',
-            '.group\\/conversation-turn',
-            'div[class*="group"]:not([class*="group"] [class*="group"])'
-        ];
-
-        let messages = [];
-        for (const selector of selectors) {
-            messages = document.querySelectorAll(selector);
-            if (messages.length > 0) {
-                console.log(`PDF: Using selector: ${selector}, found ${messages.length} messages`);
-                break;
+            try {
+                return Array.from(root.querySelectorAll(selector));
+            } catch (error) {
+                console.warn('[Chat Exporter] Selector failed:', selector, error);
+                return [];
             }
         }
 
-        if (messages.length === 0) {
-            const conversationContainer = document.querySelector('[role="main"], main, .conversation, [class*="conversation"]');
-            if (conversationContainer) {
-                messages = conversationContainer.querySelectorAll(':scope > div, :scope > article');
-                console.log(`PDF: Fallback: found ${messages.length} potential messages`);
+        function matches(element, selector) {
+            if (!element || !selector || typeof element.matches !== 'function') return false;
+
+            try {
+                return element.matches(selector);
+            } catch (error) {
+                return false;
             }
         }
 
-        const validMessages = Array.from(messages).filter(msg => {
-            const text = msg.textContent.trim();
-            return text.length >= 30 && text.length <= 100000;
-        });
+        function getText(element) {
+            if (!element) return '';
+            const innerText = typeof element.innerText === 'string' ? element.innerText : '';
+            return (innerText || element.textContent || '').replace(/\u00a0/g, ' ').trim();
+        }
 
-        const consolidatedMessages = [];
-        const usedElements = new Set();
+        function collectTextWithBreaks(node) {
+            if (!node) return '';
 
-        validMessages.forEach(msg => {
-            if (usedElements.has(msg)) return;
-            
-            const isNested = validMessages.some(other => 
-                other !== msg && other.contains(msg) && !usedElements.has(other)
-            );
-            
-            if (!isNested) {
-                consolidatedMessages.push(msg);
-                usedElements.add(msg);
+            if (node.nodeType === 3) {
+                return node.nodeValue || '';
             }
-        });
 
-        return consolidatedMessages;
-    }
+            if (node.nodeType !== 1) {
+                return '';
+            }
 
-    function identifySender(messageElement, index) {
-        const authorRole = messageElement.getAttribute('data-message-author-role');
-        if (authorRole) {
-            return authorRole === 'user' ? 'You' : 'ChatGPT';
+            const tag = node.tagName.toLowerCase();
+            if (tag === 'br') return '\n';
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+
+            const before = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+            const after = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+            return before + Array.from(node.childNodes).map(collectTextWithBreaks).join('') + after;
         }
 
-        const avatars = messageElement.querySelectorAll('img');
-        for (const avatar of avatars) {
-            const alt = avatar.alt?.toLowerCase() || '';
-            if (alt.includes('user')) return 'You';
-            if (alt.includes('chatgpt') || alt.includes('assistant')) return 'ChatGPT';
+        function getCodeText(element) {
+            if (!element) return '';
+
+            if (typeof element.innerText === 'string' && element.innerText.trim()) {
+                return element.innerText.replace(/\u00a0/g, ' ').replace(/\n{3,}/g, '\n\n').trimEnd();
+            }
+
+            const clone = element.cloneNode(true);
+            queryAll(clone, 'br').forEach(br => br.replaceWith(clone.ownerDocument.createTextNode('\n')));
+            return collectTextWithBreaks(clone).replace(/\n{3,}/g, '\n\n').trimEnd();
         }
 
-        return index % 2 === 0 ? 'You' : 'ChatGPT';
-    }
+        function normalizeCodeText(value) {
+            return String(value ?? '')
+                .replace(/\r\n?/g, '\n')
+                .replace(/^\n+/, '')
+                .replace(/\n+$/, '');
+        }
 
-    function processMessageContent(element) {
-        const clone = element.cloneNode(true);
-        const replacements = [];
+        function createTextNode(reference, text) {
+            return reference.ownerDocument.createTextNode(text);
+        }
 
-        // Do NOT use [class*="edit"]: it matches CodeMirror's "cm-editor" wrapper.
-        clone.querySelectorAll('button, svg, [class*="regenerate"], [data-testid*="copy"], [aria-label*="Copy"], [aria-label*="copy"]').forEach(el => el.remove());
-        processCodeBlocks(clone, replacements);
-        processMath(clone);
-        processMedia(clone);
-        processLinks(clone, replacements);
-        processTables(clone, replacements);
+        function addReplacement(replacements, html) {
+            const marker = `${MARKER_PREFIX}${replacements.length}__`;
+            replacements.push({ marker, html });
+            return marker;
+        }
 
-        const html = cleanText(getText(clone)).replace(/\n/g, '<br>');
-        return restoreReplacements(html, replacements);
-    }
+        function restoreReplacements(value, replacements) {
+            return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), value);
+        }
 
-    function extractTitle() {
-        const titleSelectors = [
-            'h1:not([class*="hidden"])',
-            '[class*="conversation-title"]',
-            '[data-testid*="conversation-title"]'
-        ];
+        function cleanMarkdown(markdown) {
+            return String(markdown ?? '')
+                .split(/(```[\s\S]*?```)/g)
+                .map(part => part.startsWith('```')
+                    ? part
+                    : part
+                        .replace(/[ \t]+\n/g, '\n')
+                        .replace(/\n[ \t]+/g, '\n')
+                        .replace(/\n{3,}/g, '\n\n')
+                        .replace(/&lt;/g, '<')
+                        .replace(/&gt;/g, '>')
+                        .replace(/&amp;/g, '&'))
+                .join('')
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+        }
 
-        for (const selector of titleSelectors) {
-            const element = document.querySelector(selector);
-            if (element && element.textContent.trim()) {
-                const title = element.textContent.trim();
-                if (!['chatgpt', 'new chat', 'untitled'].includes(title.toLowerCase())) {
-                    return title;
+        function escapeMarkdownLinkText(value) {
+            return String(value ?? '')
+                .replace(/\\/g, '\\\\')
+                .replace(/([\[\]])/g, '\\$1');
+        }
+
+        function escapeMarkdownUrl(value) {
+            return String(value ?? '')
+                .replace(/\\/g, '%5C')
+                .replace(/\)/g, '%29');
+        }
+
+        function isUnsafeHref(href) {
+            const lower = String(href || '').trim().toLowerCase();
+            return !lower ||
+                lower.startsWith('javascript:') ||
+                lower.startsWith('data:') ||
+                lower.startsWith('vbscript:') ||
+                lower.startsWith('#');
+        }
+
+        function topLevelElements(elements) {
+            return elements.filter(element => !elements.some(other => other !== element && other.contains(element)));
+        }
+
+        function removeUiElements(clone) {
+            const uiSelector = [
+                'button',
+                'svg',
+                'style',
+                'script',
+                'textarea',
+                'input',
+                '[contenteditable="true"]',
+                '[class*="regenerate"]',
+                '[class*="copy-button"]',
+                '[data-testid*="copy"]',
+                '[data-test-id*="copy"]',
+                '[aria-label*="Copy"]',
+                '[aria-label*="copy"]',
+                '[aria-label*="More"]',
+                '[aria-label*="more"]'
+            ].join(',');
+
+            queryAll(clone, uiSelector).forEach(element => element.remove());
+        }
+
+        function detectLanguage(block) {
+            const codeElement = matches(block, 'code') ? block : block.querySelector('code');
+            const sources = [
+                codeElement?.className,
+                block.getAttribute?.('data-language'),
+                block.getAttribute?.('language'),
+                block.getAttribute?.('lang'),
+                codeElement?.getAttribute?.('data-language'),
+                codeElement?.getAttribute?.('language'),
+                codeElement?.getAttribute?.('lang'),
+                block.getAttribute?.('aria-label')
+            ].filter(Boolean).map(String);
+
+            for (const source of sources) {
+                const languageMatch = source.match(/language-([a-zA-Z0-9_+#.-]+)/);
+                if (languageMatch) return languageMatch[1].toLowerCase();
+                if (/^[a-zA-Z0-9_+#.-]{1,24}$/.test(source) && !/^(code|copy|download)$/i.test(source)) {
+                    return source.toLowerCase();
                 }
             }
-        }
-        
-        const docTitle = document.title;
-        if (docTitle && !docTitle.toLowerCase().includes('chatgpt')) {
-            return docTitle;
-        }
-        
-        return 'ChatGPT Conversation';
-    }
 
-    function exportToPDF() {
-        const messages = findMessages();
-        
-        if (messages.length === 0) {
-            alert('No messages found. The page structure may have changed.');
-            return;
-        }
-
-        console.log(`PDF: Processing ${messages.length} messages...`);
-
-        const title = extractTitle();
-        const date = formatDate();
-        const url = window.location.href;
-
-        // Create HTML content optimized for PDF printing
-        let htmlContent = `<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>${cleanText(title)}</title>
-    <style>
-        @media print {
-            body { margin: 0; }
-            .no-print { display: none; }
-            .message { page-break-inside: avoid; }
-        }
-        
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 800px;
-            margin: 0 auto;
-            padding: 40px 20px;
-            background: white;
-        }
-        
-        h1 {
-            color: #2c3e50;
-            border-bottom: 3px solid #3498db;
-            padding-bottom: 10px;
-            margin-bottom: 30px;
-        }
-        
-        .metadata {
-            color: #666;
-            font-size: 14px;
-            margin-bottom: 30px;
-            padding-bottom: 20px;
-            border-bottom: 1px solid #e0e0e0;
-        }
-        
-        .message {
-            margin: 25px 0;
-            padding: 20px;
-            background: #f8f9fa;
-            border-radius: 8px;
-            page-break-inside: avoid;
-        }
-        
-        .message.user {
-            background: #e3f2fd;
-            margin-left: 40px;
-        }
-        
-        .message.assistant {
-            background: #f3f4f6;
-            margin-right: 40px;
-        }
-        
-        .sender {
-            font-weight: bold;
-            color: #2c3e50;
-            margin-bottom: 10px;
-            font-size: 14px;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        
-        .content {
-            color: #333;
-            white-space: pre-wrap;
-            word-wrap: break-word;
-        }
-        
-        .code-block {
-            background: #282c34;
-            color: #abb2bf;
-            padding: 15px;
-            border-radius: 5px;
-            overflow-x: auto;
-            font-family: "Courier New", monospace;
-            font-size: 14px;
-            margin: 10px 0;
-        }
-
-        .code-block code {
-            white-space: pre;
-        }
-
-        .code-language {
-            color: #d7dae0;
-            font-size: 12px;
-            margin-bottom: 8px;
-            text-transform: uppercase;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            margin: 12px 0;
-            font-size: 14px;
-        }
-
-        th, td {
-            border: 1px solid #d9dde3;
-            padding: 8px;
-            text-align: left;
-            vertical-align: top;
-        }
-
-        th {
-            background: #eef2f7;
-        }
-        
-        .instructions {
-            background: #fff3cd;
-            border: 2px solid #ffc107;
-            border-radius: 8px;
-            padding: 20px;
-            margin: 30px 0;
-        }
-        
-        .instructions h3 {
-            margin-top: 0;
-            color: #856404;
-        }
-        
-        @media screen {
-            .instructions {
-                position: sticky;
-                top: 20px;
-                z-index: 1000;
+            const header = block.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code"], [data-test-id*="code"], .code-language, .code-lang, [slot="header"]');
+            const headerText = normalizeWhitespace(getText(header)).replace(/\b(copy|code|download)\b/gi, '').trim();
+            if (headerText && headerText.length < 32 && !headerText.includes('\n')) {
+                return headerText.toLowerCase();
             }
+
+            return '';
         }
-    </style>
-</head>
-<body>
-    <div class="instructions no-print">
-        <h3>📄 Convert to PDF</h3>
-        <ol>
-            <li>Press <strong>Ctrl+P</strong> (Windows/Linux) or <strong>Cmd+P</strong> (Mac)</li>
-            <li>Set "Destination" to <strong>"Save as PDF"</strong></li>
-            <li>Choose your preferred settings (recommend "Letter" or "A4" size)</li>
-            <li>Click <strong>"Save"</strong></li>
-        </ol>
-        <p><em>This instruction box will not appear in the PDF.</em></p>
-    </div>
 
-    <h1>${cleanText(title)}</h1>
-    
-    <div class="metadata">
-        <p><strong>Date:</strong> ${date}</p>
-        <p><strong>Source:</strong> <a href="${url}">${url}</a></p>
-        <p><strong>Messages:</strong> ${messages.length}</p>
-    </div>
-    
-    <div class="conversation">`;
+        function extractCodeBlock(block) {
+            const clone = block.cloneNode(true);
+            const language = detectLanguage(clone);
 
-        // Process messages
-        const seenContent = new Set();
-        let processedCount = 0;
+            queryAll(clone, 'button, svg, [aria-label*="Copy"], [aria-label*="copy"], [class*="sticky"], [class*="code-header"], [data-testid*="copy"], [data-test-id*="copy"], [slot="header"]').forEach(element => element.remove());
 
-        messages.forEach((messageElement, index) => {
-            const sender = identifySender(messageElement, index);
-            const content = processMessageContent(messageElement);
-            
-            if (!content || content.replace(/<[^>]*>/g, '').trim().length < 10) return;
-            
-            const contentHash = content.replace(/<[^>]*>/g, ' ').substring(0, 100).replace(/\s+/g, ' ');
-            if (seenContent.has(contentHash)) return;
-            seenContent.add(contentHash);
-            
-            const senderClass = sender.toLowerCase() === 'you' ? 'user' : 'assistant';
-            
-            htmlContent += `
-        <div class="message ${senderClass}">
-            <div class="sender">${cleanText(sender)}</div>
-            <div class="content">${content}</div>
-        </div>`;
-            
-            processedCount++;
+            const cmContent = clone.querySelector('.cm-content');
+            if (cmContent) {
+                const cmLines = queryAll(cmContent, '.cm-line');
+                if (cmLines.length > 0) {
+                    return {
+                        lang: language,
+                        code: normalizeCodeText(cmLines.map(line => line.textContent || '').join('\n'))
+                    };
+                }
+
+                return {
+                    lang: language,
+                    code: normalizeCodeText(getCodeText(cmContent))
+                };
+            }
+
+            const codeElement = matches(clone, 'code') ? clone : clone.querySelector('code');
+            return {
+                lang: language,
+                code: normalizeCodeText(getCodeText(codeElement || clone))
+            };
+        }
+
+        function formatCodeBlock(block, format, replacements) {
+            const { lang, code } = extractCodeBlock(block);
+
+            if (format === 'markdown') {
+                return `\n\n\`\`\`${lang}\n${code}\n\`\`\`\n\n`;
+            }
+
+            const langClass = lang ? ` class="language-${sanitizeHtml(lang)}"` : '';
+            if (format === 'pdf') {
+                const label = lang ? `<div class="code-language">${sanitizeHtml(lang)}</div>` : '';
+                return addReplacement(replacements, `<pre class="code-block">${label}<code>${sanitizeHtml(code)}</code></pre>`);
+            }
+
+            return addReplacement(replacements, `<pre><code${langClass}>${sanitizeHtml(code)}</code></pre>`);
+        }
+
+        function processCodeBlocks(clone, format, replacements) {
+            const blocks = topLevelElements(queryAll(clone, 'pre, code-block, [data-testid*="code-block"], [data-test-id*="code-block"]'));
+
+            blocks.forEach(block => {
+                const replacement = formatCodeBlock(block, format, replacements);
+                block.replaceWith(createTextNode(block, replacement));
+            });
+        }
+
+        function processMath(clone) {
+            const processed = new Set();
+
+            queryAll(clone, 'annotation').forEach(annotation => {
+                const encoding = (annotation.getAttribute('encoding') || '').toLowerCase();
+                if (!encoding.includes('tex') && !encoding.includes('latex')) return;
+
+                const tex = annotation.textContent.trim();
+                if (!tex) return;
+
+                const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
+                const mathRoot = displayRoot || annotation.closest('.katex') || annotation.closest('mjx-container') || annotation.closest('math');
+                if (!mathRoot || processed.has(mathRoot)) return;
+
+                processed.add(mathRoot);
+                mathRoot.replaceWith(createTextNode(mathRoot, displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+            });
+
+            queryAll(clone, 'script[type^="math/tex"]').forEach(script => {
+                const tex = script.textContent.trim();
+                if (!tex) return;
+                const isDisplay = /mode=display/.test(script.type);
+                script.replaceWith(createTextNode(script, isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+            });
+        }
+
+        function processMedia(clone, format, replacements) {
+            queryAll(clone, 'img, canvas, video, audio').forEach(element => {
+                const tag = element.tagName.toLowerCase();
+                const alt = normalizeWhitespace(element.getAttribute('alt') || element.getAttribute('aria-label') || element.getAttribute('title') || '');
+                const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                    tag === 'img' ? '[Image]' :
+                    tag === 'canvas' ? '[Canvas or chart]' :
+                    tag === 'video' ? '[Video]' :
+                    tag === 'audio' ? '[Audio]' :
+                    '[Media]';
+
+                const replacement = format === 'markdown'
+                    ? label
+                    : addReplacement(replacements, `<span class="media-placeholder">${sanitizeHtml(label)}</span>`);
+                element.replaceWith(createTextNode(element, replacement));
+            });
+        }
+
+        function processLinks(clone, format, replacements) {
+            queryAll(clone, 'a[href]').forEach(link => {
+                if (link.closest('pre, code, code-block')) return;
+
+                const href = String(link.href || link.getAttribute('href') || '').trim();
+                if (isUnsafeHref(href)) return;
+
+                const text = normalizeWhitespace(link.textContent) || href;
+                const replacement = format === 'markdown'
+                    ? `[${escapeMarkdownLinkText(text)}](${escapeMarkdownUrl(href)})`
+                    : addReplacement(replacements, `<a href="${sanitizeHtml(href)}">${sanitizeHtml(text)}</a>`);
+
+                link.replaceWith(createTextNode(link, replacement));
+            });
+        }
+
+        function tableCellText(cell) {
+            return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+        }
+
+        function tableToMarkdown(table) {
+            const rows = queryAll(table, 'tr')
+                .map(row => Array.from(row.children)
+                    .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                    .map(tableCellText))
+                .filter(row => row.length > 0);
+
+            if (rows.length === 0) return normalizeWhitespace(getText(table));
+
+            const width = Math.max(...rows.map(row => row.length));
+            const normalizedRows = rows.map(row => row.concat(Array(Math.max(0, width - row.length)).fill(' ')));
+            const header = normalizedRows[0];
+            const separator = header.map(() => '---');
+            const body = normalizedRows.slice(1);
+
+            return [
+                `| ${header.join(' | ')} |`,
+                `| ${separator.join(' | ')} |`,
+                ...body.map(row => `| ${row.join(' | ')} |`)
+            ].join('\n');
+        }
+
+        function tableToHtml(table) {
+            const rows = queryAll(table, 'tr')
+                .map(row => Array.from(row.children)
+                    .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                    .map(cell => ({
+                        tag: cell.tagName.toLowerCase(),
+                        text: normalizeWhitespace(getText(cell))
+                    })))
+                .filter(row => row.length > 0);
+
+            if (rows.length === 0) return sanitizeHtml(getText(table));
+
+            return `<table>${rows.map(row => {
+                const cells = row.map(cell => `<${cell.tag}>${sanitizeHtml(cell.text)}</${cell.tag}>`).join('');
+                return `<tr>${cells}</tr>`;
+            }).join('')}</table>`;
+        }
+
+        function processTables(clone, format, replacements) {
+            topLevelElements(queryAll(clone, 'table')).forEach(table => {
+                const replacement = format === 'markdown'
+                    ? `\n\n${tableToMarkdown(table)}\n\n`
+                    : addReplacement(replacements, tableToHtml(table));
+                table.replaceWith(createTextNode(table, replacement));
+            });
+        }
+
+        function cardSignal(element) {
+            const pieces = [
+                element.tagName,
+                getClassName(element),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id'),
+                element.getAttribute('aria-label'),
+                element.getAttribute('role')
+            ].filter(Boolean).join(' ').toLowerCase();
+
+            if (/\b(artifact|canvas-preview|generated-file|download-card|attachment|file-card)\b/.test(pieces)) {
+                return pieces.includes('artifact') || pieces.includes('canvas-preview') ? 'Artifact' : 'File';
+            }
+
+            if (/(^|[\s_-])(attachment|file)([\s_-]|$)/.test(pieces)) {
+                return 'File';
+            }
+
+            return '';
+        }
+
+        function cardLabel(element) {
+            const candidates = [
+                element.getAttribute('aria-label'),
+                element.getAttribute('title'),
+                element.getAttribute('download'),
+                element.getAttribute('data-filename'),
+                getText(element)
+            ].filter(Boolean).map(normalizeWhitespace);
+
+            const label = candidates.find(value => value && value.length <= 180) || '';
+            return label
+                .replace(/\b(open|download|preview|file|attachment|artifact)\b/gi, ' ')
+                .replace(/\s+/g, ' ')
+                .trim();
+        }
+
+        function processCards(clone, format, replacements) {
+            const cards = topLevelElements(Array.from(clone.querySelectorAll('*')).filter(element => {
+                const kind = cardSignal(element);
+                if (!kind) return false;
+                if (matches(element, '[data-message-author-role], user-query, model-response')) return false;
+                if (element.closest('pre, code, code-block, table')) return false;
+                if (element.querySelector('pre, code-block, table, user-query, model-response')) return false;
+
+                const text = normalizeWhitespace(getText(element));
+                const label = cardLabel(element);
+                return Boolean(label || text) && text.length <= 240;
+            }));
+
+            cards.forEach(card => {
+                const kind = cardSignal(card);
+                const label = cardLabel(card);
+                const text = label ? `[${kind}: ${label}]` : `[${kind}]`;
+                const replacement = format === 'markdown'
+                    ? text
+                    : addReplacement(replacements, `<span class="card-placeholder">${sanitizeHtml(text)}</span>`);
+                card.replaceWith(createTextNode(card, replacement));
+            });
+        }
+
+        function serializeMarkdownChildren(element, context = {}) {
+            return Array.from(element.childNodes).map((node, index) => serializeMarkdownNode(node, {
+                ...context,
+                index
+            })).join('');
+        }
+
+        function serializeMarkdownNode(node, context = {}) {
+            if (node.nodeType === 3) {
+                const value = node.nodeValue || '';
+                if (value.includes('```') || value.includes('| ---') || value.includes(MARKER_PREFIX) || value.match(/^\s*\[[^\]]+\]/)) {
+                    return value;
+                }
+                return value.replace(/[ \t\r\n]+/g, ' ');
+            }
+
+            if (node.nodeType !== 1) return '';
+
+            const tag = node.tagName.toLowerCase();
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+            if (tag === 'br') return '\n';
+
+            if (/^h[1-6]$/.test(tag)) {
+                const level = Number(tag.slice(1));
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${'#'.repeat(level)} ${content}\n\n` : '';
+            }
+
+            if (tag === 'p') {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${content}\n\n` : '';
+            }
+
+            if (tag === 'blockquote') {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${content.split('\n').map(line => `> ${line.trim()}`).join('\n')}\n\n` : '';
+            }
+
+            if (tag === 'ul' || tag === 'ol') {
+                const children = Array.from(node.children).filter(child => child.tagName && child.tagName.toLowerCase() === 'li');
+                return `\n${children.map((child, index) => serializeMarkdownNode(child, {
+                    ...context,
+                    listType: tag,
+                    index,
+                    depth: (context.depth || 0)
+                })).join('')}\n`;
+            }
+
+            if (tag === 'li') {
+                const depth = context.depth || 0;
+                const marker = context.listType === 'ol' ? `${(context.index || 0) + 1}. ` : '- ';
+                const indent = '  '.repeat(depth);
+                const content = serializeMarkdownChildren(node, {
+                    ...context,
+                    depth: depth + 1
+                }).trim();
+                return content ? `${indent}${marker}${content.replace(/\n+/g, `\n${indent}  `)}\n` : '';
+            }
+
+            if (['strong', 'b'].includes(tag)) {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `**${content}**` : '';
+            }
+
+            if (['em', 'i'].includes(tag)) {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `*${content}*` : '';
+            }
+
+            if (tag === 'code') {
+                const content = getCodeText(node).replace(/`/g, '\\`').trim();
+                return content ? `\`${content}\`` : '';
+            }
+
+            const content = serializeMarkdownChildren(node, context);
+            if (['div', 'section', 'article', 'main', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+                return content;
+            }
+
+            return content;
+        }
+
+        function serializeHtmlChildren(element, replacements) {
+            return Array.from(element.childNodes).map(node => serializeHtmlNode(node, replacements)).join('');
+        }
+
+        function serializeHtmlNode(node, replacements) {
+            if (node.nodeType === 3) {
+                return sanitizeHtml(node.nodeValue || '');
+            }
+
+            if (node.nodeType !== 1) return '';
+
+            const tag = node.tagName.toLowerCase();
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+            if (tag === 'br') return '<br>';
+
+            const content = serializeHtmlChildren(node, replacements);
+            const blockTags = new Set(['p', 'ul', 'ol', 'li', 'blockquote', 'strong', 'b', 'em', 'i']);
+
+            if (/^h[1-6]$/.test(tag)) {
+                return `<${tag}>${content}</${tag}>`;
+            }
+
+            if (blockTags.has(tag)) {
+                const safeTag = tag === 'b' ? 'strong' : tag === 'i' ? 'em' : tag;
+                return `<${safeTag}>${content}</${safeTag}>`;
+            }
+
+            if (tag === 'code') {
+                return `<code>${sanitizeHtml(getCodeText(node).trim())}</code>`;
+            }
+
+            if (['div', 'section', 'article', 'main', 'span', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+                return content;
+            }
+
+            return content;
+        }
+
+        function serializeMessageContent(element, format) {
+            const clone = element.cloneNode(true);
+            const replacements = [];
+
+            removeUiElements(clone);
+            processCards(clone, format, replacements);
+            processCodeBlocks(clone, format, replacements);
+            processMath(clone);
+            processMedia(clone, format, replacements);
+            processLinks(clone, format, replacements);
+            processTables(clone, format, replacements);
+
+            if (format === 'markdown') {
+                return cleanMarkdown(serializeMarkdownChildren(clone));
+            }
+
+            const html = serializeHtmlChildren(clone, replacements)
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+            return restoreReplacements(html, replacements);
+        }
+
+        function detectProvider(doc) {
+            const url = doc.defaultView?.location?.href || '';
+            if (/gemini\.google\.com/i.test(url) || doc.querySelector('user-query, model-response')) return 'gemini';
+            return 'chatgpt';
+        }
+
+        function providerFor(providerName, doc) {
+            const id = providerName || detectProvider(doc);
+            return PROVIDERS[id] || PROVIDERS.chatgpt;
+        }
+
+        function meaningfulScore(element) {
+            const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+            return normalizeWhitespace(element.textContent).length + richCount * 200;
+        }
+
+        function isValidMessage(element) {
+            const text = normalizeWhitespace(element.textContent);
+            const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+
+            if (text.length < 5 && richCount === 0) return false;
+            if (text.length > 200000) return false;
+            if (matches(element, 'nav, aside, header, footer, form, menu')) return false;
+            if (element.querySelector('textarea, input[type="text"], [contenteditable="true"]') && !element.hasAttribute('data-message-author-role')) return false;
+            if (getClassName(element).match(/\b(typing|loading|spinner)\b/i)) return false;
+
+            return true;
+        }
+
+        function findMessages(doc, provider) {
+            for (const selector of provider.messageSelectors) {
+                const messages = topLevelElements(queryAll(doc, selector)).filter(isValidMessage);
+                if (messages.length > 0) {
+                    console.log(`[Chat Exporter] ${provider.id}: using selector "${selector}" (${messages.length} messages)`);
+                    return messages;
+                }
+            }
+
+            const container = doc.querySelector('[role="main"], main, [class*="conversation"], [class*="chat"]');
+            if (!container) return [];
+
+            return topLevelElements(queryAll(container, ':scope > article, :scope > section, :scope > div')).filter(isValidMessage);
+        }
+
+        function selectContentRoot(messageElement, provider) {
+            const candidates = [messageElement];
+
+            provider.contentSelectors.forEach(selector => {
+                if (matches(messageElement, selector)) candidates.push(messageElement);
+                candidates.push(...queryAll(messageElement, selector));
+            });
+
+            return candidates
+                .filter(Boolean)
+                .sort((a, b) => meaningfulScore(b) - meaningfulScore(a))[0] || messageElement;
+        }
+
+        function identifySender(element, index, provider) {
+            const tag = element.tagName.toLowerCase();
+            if (tag === 'user-query') return { sender: 'You', reliable: true };
+            if (tag === 'model-response') return { sender: provider.assistantName, reliable: true };
+
+            const role = element.getAttribute('data-message-author-role') || element.getAttribute('data-author') || element.getAttribute('data-sender');
+            if (role) {
+                const normalizedRole = role.toLowerCase();
+                if (normalizedRole === 'user') return { sender: 'You', reliable: true };
+                if (['assistant', 'model', 'bot', 'chatgpt', 'gemini'].includes(normalizedRole)) {
+                    return { sender: provider.assistantName, reliable: true };
+                }
+            }
+
+            const classAndAttrs = [
+                getClassName(element),
+                element.getAttribute('aria-label'),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id')
+            ].filter(Boolean).join(' ').toLowerCase();
+
+            if (classAndAttrs.match(/\b(user|human|query)\b/)) return { sender: 'You', reliable: false };
+            if (classAndAttrs.match(/\b(assistant|model|response|chatgpt|gemini|bard)\b/)) return { sender: provider.assistantName, reliable: false };
+
+            const textStart = normalizeWhitespace(element.textContent).slice(0, 220).toLowerCase();
+            if (/^(i understand|i can help|here's|i'll|let me|i'd be happy|certainly|of course|absolutely)/.test(textStart)) {
+                return { sender: provider.assistantName, reliable: false };
+            }
+
+            if (/^(can you|please help|how do i|i need|i want|help me|could you|explain|what is)/.test(textStart)) {
+                return { sender: 'You', reliable: false };
+            }
+
+            return { sender: index % 2 === 0 ? 'You' : provider.assistantName, reliable: false };
+        }
+
+        function contentHash(content) {
+            return normalizeWhitespace(String(content || '').replace(/<[^>]+>/g, ' ')).slice(0, 160);
+        }
+
+        function extractConversation(options = {}) {
+            const doc = resolveDocument(options.document);
+            const provider = providerFor(options.provider, doc);
+            const format = options.format || 'markdown';
+            const rawMessages = findMessages(doc, provider);
+            const seen = new Set();
+            const messages = [];
+
+            rawMessages.forEach((messageElement, index) => {
+                const contentRoot = selectContentRoot(messageElement, provider);
+                const content = serializeMessageContent(contentRoot, format);
+                const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
+
+                if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+
+                const hash = contentHash(content);
+                if (seen.has(hash)) return;
+                seen.add(hash);
+
+                const sender = identifySender(messageElement, index, provider);
+                messages.push({
+                    sender: sender.sender,
+                    senderType: sender.sender === 'You' ? 'user' : 'assistant',
+                    reliableSender: sender.reliable,
+                    content,
+                    index
+                });
+            });
+
+            return {
+                version: ENGINE_VERSION,
+                provider: provider.id,
+                providerLabel: provider.assistantName,
+                sourceLabel: provider.sourceLabel,
+                title: extractConversationTitle(doc, provider),
+                sourceUrl: doc.defaultView?.location?.href || '',
+                date: formatDate(options.date || new Date()),
+                messages
+            };
+        }
+
+        function extractConversationTitle(doc, provider) {
+            for (const selector of provider.titleSelectors) {
+                const element = doc.querySelector(selector);
+                const title = normalizeWhitespace(element?.textContent);
+                if (title && !provider.genericTitlePattern.test(title)) return title;
+            }
+
+            const docTitle = normalizeWhitespace(doc.title);
+            if (docTitle && !provider.genericTitlePattern.test(docTitle)) return docTitle;
+
+            return provider.defaultTitle;
+        }
+
+        function renderMarkdown(conversation) {
+            const lines = [
+                `# ${conversation.title}\n`,
+                `**Date:** ${conversation.date}`,
+                `**Source:** [${conversation.sourceLabel}](${conversation.sourceUrl})\n`,
+                '---\n'
+            ];
+
+            conversation.messages.forEach(message => {
+                lines.push(`### **${message.sender}**\n`, message.content, '\n---\n');
+            });
+
+            return `${lines.join('\n').trim()}\n`;
+        }
+
+        function renderHtmlDocument(conversation, options = {}) {
+            const isPdf = options.format === 'pdf';
+            const source = sanitizeHtml(conversation.sourceUrl);
+            const title = sanitizeHtml(conversation.title);
+            const messages = conversation.messages.map(message => {
+                const senderClass = message.senderType === 'user' ? 'user' : 'assistant';
+                return `
+            <div class="message ${senderClass}">
+                <div class="sender">${sanitizeHtml(message.sender)}</div>
+                <div class="content">${message.content}</div>
+            </div>`;
+            }).join('');
+
+            const pdfInstructions = isPdf ? `
+        <div class="instructions no-print">
+            <h3>Convert to PDF</h3>
+            <ol>
+                <li>Press Ctrl+P on Windows/Linux or Cmd+P on Mac.</li>
+                <li>Set Destination to Save as PDF.</li>
+                <li>Choose your preferred page size.</li>
+                <li>Click Save.</li>
+            </ol>
+            <p><em>This instruction box will not appear in the PDF.</em></p>
+        </div>` : '';
+
+            return `<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <title>${title} - ${conversation.date}</title>
+        <style>
+            @media print {
+                body { margin: 0; }
+                .no-print { display: none; }
+                .message { page-break-inside: avoid; }
+            }
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+                max-width: 840px;
+                margin: auto;
+                padding: 2rem;
+                background: #fff;
+                color: #333;
+                line-height: 1.6;
+            }
+            .header {
+                text-align: center;
+                margin-bottom: 2rem;
+                padding-bottom: 1rem;
+                border-bottom: 2px solid #eee;
+            }
+            .metadata {
+                color: #666;
+                font-size: 0.9rem;
+            }
+            .message {
+                margin-bottom: 1.5rem;
+                padding: 1rem;
+                border-radius: 8px;
+                background: #f8f9fa;
+            }
+            .message.user {
+                background: #eaf4ff;
+            }
+            .sender {
+                font-weight: 700;
+                color: #2c3e50;
+                margin-bottom: 0.5rem;
+            }
+            .content {
+                white-space: pre-wrap;
+                overflow-wrap: anywhere;
+            }
+            pre {
+                background: #f4f4f4;
+                padding: 1rem;
+                border-radius: 4px;
+                overflow-x: auto;
+                border-left: 4px solid #007acc;
+            }
+            .code-block {
+                background: #282c34;
+                color: #abb2bf;
+                border-left: 0;
+            }
+            .code-block code {
+                white-space: pre;
+            }
+            .code-language {
+                color: #d7dae0;
+                font-size: 12px;
+                margin-bottom: 8px;
+                text-transform: uppercase;
+            }
+            code {
+                font-family: Consolas, Monaco, "Courier New", monospace;
+                font-size: 0.92rem;
+            }
+            table {
+                width: 100%;
+                border-collapse: collapse;
+                margin: 1rem 0;
+            }
+            th, td {
+                border: 1px solid #d9dde3;
+                padding: 0.5rem;
+                text-align: left;
+                vertical-align: top;
+            }
+            th {
+                background: #eef2f7;
+            }
+            .instructions {
+                background: #fff8dc;
+                border: 1px solid #e3c565;
+                border-radius: 8px;
+                padding: 1rem;
+                margin-bottom: 1.5rem;
+            }
+        </style>
+    </head>
+    <body>
+        ${pdfInstructions}
+        <div class="header">
+            <h1>${title}</h1>
+            <div class="metadata">
+                <div><strong>Date:</strong> ${sanitizeHtml(conversation.date)}</div>
+                <div><strong>Source:</strong> <a href="${source}">${sanitizeHtml(conversation.sourceLabel)}</a></div>
+                <div><strong>Messages:</strong> ${conversation.messages.length}</div>
+            </div>
+        </div>
+        <div class="conversation">${messages}
+        </div>
+    </body>
+    </html>`;
+        }
+
+        function render(conversation, format) {
+            if (format === 'markdown') return renderMarkdown(conversation);
+            if (format === 'pdf') return renderHtmlDocument(conversation, { format: 'pdf' });
+            if (format === 'html') return renderHtmlDocument(conversation, { format: 'html' });
+            throw new Error(`Unsupported export format: ${format}`);
+        }
+
+        function filenameFor(conversation, format, doc) {
+            const safeTitle = normalizeWhitespace(doc.title || conversation.title)
+                .replace(/[<>:"/\\|?*]/g, '')
+                .slice(0, 120);
+
+            if (format === 'markdown') {
+                return safeTitle ? `${safeTitle} (${conversation.date}).md` : `${conversation.providerLabel}_Conversation_${conversation.date}.md`;
+            }
+
+            if (format === 'pdf') {
+                return safeTitle ? `${safeTitle} (${conversation.date}) - PrintToPDF.html` : `${conversation.providerLabel}_Conversation_${conversation.date}_PrintToPDF.html`;
+            }
+
+            return safeTitle ? `${safeTitle} (${conversation.date}).html` : `${conversation.providerLabel}_Conversation_${conversation.date}.html`;
+        }
+
+        function mimeFor(format) {
+            return format === 'markdown' ? 'text/markdown' : 'text/html';
+        }
+
+        function downloadFile(doc, content, filename, mimeType) {
+            const win = getWindow(doc);
+            const BlobCtor = win?.Blob || Blob;
+            const urlApi = win?.URL || URL;
+            const blob = new BlobCtor([content], { type: mimeType });
+            const url = urlApi.createObjectURL(blob);
+            const anchor = doc.createElement('a');
+
+            anchor.href = url;
+            anchor.download = filename;
+            doc.body.appendChild(anchor);
+            anchor.click();
+            doc.body.removeChild(anchor);
+            urlApi.revokeObjectURL(url);
+        }
+
+        function exportConversation(options = {}) {
+            const doc = resolveDocument(options.document);
+            const format = options.format || 'markdown';
+            const conversation = extractConversation({
+                ...options,
+                document: doc,
+                format
+            });
+
+            if (conversation.messages.length === 0) {
+                const message = 'No messages found. The page structure may have changed.';
+                const win = getWindow(doc);
+                if (typeof win?.alert === 'function') win.alert(message);
+                console.warn(`[Chat Exporter] ${message}`);
+                return { conversation, content: '' };
+            }
+
+            const content = render(conversation, format);
+            const filename = options.filename || filenameFor(conversation, format, doc);
+
+            if (options.download !== false) {
+                downloadFile(doc, content, filename, mimeFor(format));
+                console.log(`[Chat Exporter] Exported ${conversation.messages.length} messages to ${filename}`);
+            }
+
+            return { conversation, content, filename };
+        }
+
+        return {
+            version: ENGINE_VERSION,
+            providers: PROVIDERS,
+            detectProvider,
+            extractConversation,
+            exportConversation,
+            serializers: {
+                markdown: renderMarkdown,
+                html: conversation => renderHtmlDocument(conversation, { format: 'html' }),
+                pdf: conversation => renderHtmlDocument(conversation, { format: 'pdf' })
+            },
+            internals: {
+                serializeMessageContent,
+                extractCodeBlock,
+                tableToMarkdown,
+                tableToHtml
+            }
+        };
+    });
+
+    function runExport() {
+        globalThis.ChatExporterEngine.exportConversation({
+            provider: 'chatgpt',
+            format: 'pdf'
         });
-
-        htmlContent += `
-    </div>
-</body>
-</html>`;
-
-        // Create blob and download
-        const blob = new Blob([htmlContent], { type: 'text/html' });
-        const url2 = URL.createObjectURL(blob);
-        
-        // Create download link
-        const a = document.createElement('a');
-        a.href = url2;
-        const safeTitle = document.title.replace(/[<>:"/\\|?*]/g, '').replace(/\s+/g, ' ').trim();
-        a.download = safeTitle ? `${safeTitle} (${date}) - PrintToPDF.html` : `ChatGPT_Conversation_${date}_PrintToPDF.html`;
-        
-        // Auto-download
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url2);
-
-        console.log(`PDF: Export completed - ${processedCount} messages processed`);
-        console.log('PDF: The HTML file has been downloaded. Open it and press Ctrl+P (Cmd+P on Mac) to save as PDF.');
-        
-        // Show instructions
-        alert(`✅ Export Complete!\n\n${processedCount} messages exported.\n\nTo create PDF:\n1. Open the downloaded HTML file\n2. Press Ctrl+P (Cmd+P on Mac)\n3. Choose "Save as PDF"\n4. Click Save\n\nThe yellow instruction box will not appear in the PDF.`);
     }
 
-    // Add export button to the page
     function addExportButton() {
-        // Check if button already exists
         if (document.querySelector('#chatgpt-export-pdf-btn')) return;
 
         const button = document.createElement('button');
         button.id = 'chatgpt-export-pdf-btn';
-        button.textContent = 'Export as PDF';
-        button.style.cssText = `
-            position: fixed;
-            bottom: 20px;
-            right: 180px;
-            padding: 10px 20px;
-            background-color: #3498db;
-            color: white;
-            border: none;
-            border-radius: 5px;
-            cursor: pointer;
-            z-index: 10000;
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            font-size: 14px;
-            font-weight: 500;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        `;
-        
-        button.addEventListener('click', exportToPDF);
+        button.textContent = 'Export PDF';
+        button.style.cssText = [
+            'position: fixed',
+            'bottom: 20px',
+            'right: 170px',
+            'padding: 10px 16px',
+            'background-color: #3498db',
+            'color: white',
+            'border: none',
+            'border-radius: 5px',
+            'cursor: pointer',
+            'z-index: 10000',
+            'font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+            'font-size: 14px',
+            'font-weight: 600',
+            'box-shadow: 0 2px 4px rgba(0,0,0,0.2)'
+        ].join(';');
+
+        button.addEventListener('click', runExport);
         button.addEventListener('mouseenter', () => {
             button.style.backgroundColor = '#2c7fb8';
         });
         button.addEventListener('mouseleave', () => {
             button.style.backgroundColor = '#3498db';
         });
-        
+
         document.body.appendChild(button);
     }
 
-    // Wait for page to load
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', addExportButton);
-    } else {
-        // Add button after a short delay to ensure page is fully loaded
-        setTimeout(addExportButton, 1000);
+    function installButton() {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => setTimeout(addExportButton, 1000), { once: true });
+        } else {
+            setTimeout(addExportButton, 1000);
+        }
+
+        const observer = new MutationObserver(() => {
+            if (!document.querySelector('#chatgpt-export-pdf-btn')) addExportButton();
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
     }
 
-    // Re-add button if navigation changes (for SPAs)
-    const observer = new MutationObserver(() => {
-        if (!document.querySelector('#chatgpt-export-pdf-btn')) {
-            addExportButton();
-        }
-    });
-    
-    observer.observe(document.body, { childList: true, subtree: true });
+    installButton();
 })();

--- a/exporter-html.js
+++ b/exporter-html.js
@@ -397,7 +397,9 @@
         }
 
         function tableCellText(cell) {
-            return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+            return normalizeWhitespace(getText(cell))
+                .replace(/\\/g, '\\\\')
+                .replace(/\|/g, '\\|') || ' ';
         }
 
         function tableToMarkdown(table) {
@@ -580,7 +582,10 @@
             }
 
             if (tag === 'code') {
-                const content = getCodeText(node).replace(/`/g, '\\`').trim();
+                const content = getCodeText(node)
+                    .replace(/\\/g, '\\\\')
+                    .replace(/`/g, '\\`')
+                    .trim();
                 return content ? `\`${content}\`` : '';
             }
 
@@ -762,7 +767,7 @@
                 const content = serializeMessageContent(contentRoot, format);
                 const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
 
-                if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+                if (!content || normalizeWhitespace(content).length < minLength) return;
 
                 const hash = contentHash(content);
                 if (seen.has(hash)) return;

--- a/exporter-html.js
+++ b/exporter-html.js
@@ -1,509 +1,1053 @@
+// Generated from src/extraction-engine.js by scripts/build-exporters.js.
+// Edit the source engine or this build script, then run npm run build.
+
 (() => {
-    function formatDate(date = new Date()) {
-        return date.toISOString().split('T')[0];
-    }
+    'use strict';
 
-    function sanitize(text) {
-        return text
-            .replace(/&/g, '&amp;')  // Replace & first to avoid double-escaping
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
-    }
+    (function initChatExporterEngine(root, factory) {
+        const engine = factory();
 
-    function getText(element) {
-        return (element?.innerText ?? element?.textContent ?? '').trim();
-    }
-
-    function removeUiElements(clone) {
-        clone.querySelectorAll('button, svg, [class*="regenerate"], [data-testid*="copy"], [aria-label*="Copy"], [aria-label*="copy"]').forEach(el => el.remove());
-    }
-
-    function extractCodeBlock(pre) {
-        const codeEl = pre.querySelector('code');
-        const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9_-]+)/);
-        let lang = langMatch ? langMatch[1] : '';
-
-        if (!lang) {
-            const header = pre.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code-block"]');
-            const headerText = getText(header).replace(/\b(copy|code|download)\b/gi, '').trim();
-            if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
-                lang = headerText.toLowerCase();
-            }
-            header?.remove();
+        if (root) {
+            root.ChatExporterEngine = engine;
         }
 
-        const cmContent = pre.querySelector('.cm-content');
-        if (cmContent) {
-            const cmLines = cmContent.querySelectorAll('.cm-line');
-            if (cmLines.length > 0) {
-                return { lang, code: Array.from(cmLines).map(line => line.textContent).join('\n').trim() };
-            }
+        if (typeof module !== 'undefined' && module.exports) {
+            module.exports = engine;
+        }
+    })(typeof globalThis !== 'undefined' ? globalThis : this, function buildChatExporterEngine() {
+        'use strict';
 
-            cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
-            return { lang, code: cmContent.textContent.trim() };
+        const ENGINE_VERSION = '0.7.0-live-engine';
+        const MARKER_PREFIX = '__CHAT_EXPORTER_BLOCK_';
+
+        const PROVIDERS = {
+            chatgpt: {
+                id: 'chatgpt',
+                assistantName: 'ChatGPT',
+                sourceLabel: 'chatgpt.com',
+                defaultTitle: 'Conversation with ChatGPT',
+                genericTitlePattern: /^(chatgpt|new chat|untitled|chat)$/i,
+                messageSelectors: [
+                    'div[data-message-author-role]',
+                    'article[data-testid*="conversation-turn"]',
+                    'div[data-testid="conversation-turn"]',
+                    '.group\\/conversation-turn',
+                    '[data-testid*="message"], [data-message-id], [data-message-author]'
+                ],
+                contentSelectors: [
+                    '.markdown, .prose, [class*="markdown"], [class*="prose"]',
+                    '[data-message-content], [data-testid*="content"]',
+                    '.whitespace-pre-wrap, [class*="whitespace"]'
+                ],
+                titleSelectors: [
+                    'h1:not([class*="hidden"])',
+                    '[class*="conversation-title"]',
+                    '[data-testid*="conversation-title"]'
+                ]
+            },
+            gemini: {
+                id: 'gemini',
+                assistantName: 'Gemini',
+                sourceLabel: 'gemini.google.com',
+                defaultTitle: 'Conversation with Gemini',
+                genericTitlePattern: /^(gemini|new chat|untitled|chat|bard)$/i,
+                messageSelectors: [
+                    'user-query, model-response',
+                    '[data-test-id="conversation-turn"]',
+                    '[data-testid="conversation-turn"]',
+                    '[data-message-author-role]',
+                    '[class*="conversation-turn"]',
+                    '[role="listitem"]'
+                ],
+                contentSelectors: [
+                    'message-content',
+                    '.query-text',
+                    '.response-container',
+                    '.markdown, .prose, [class*="markdown"], [class*="prose"]'
+                ],
+                titleSelectors: [
+                    'h1:not([class*="hidden"])',
+                    '[class*="conversation-title"]',
+                    '[data-testid*="conversation-title"]',
+                    '[aria-label*="conversation"]'
+                ]
+            }
+        };
+
+        function resolveDocument(doc) {
+            if (doc) return doc;
+            if (typeof document !== 'undefined') return document;
+            throw new Error('ChatExporterEngine requires a document.');
         }
 
-        return { lang, code: getText(codeEl || pre) };
-    }
+        function getWindow(doc) {
+            return doc.defaultView || (typeof window !== 'undefined' ? window : null);
+        }
 
-    function addReplacement(replacements, html) {
-        const marker = `EXPORTER_BLOCK_${replacements.length}`;
-        replacements.push({ marker, html });
-        return marker;
-    }
+        function formatDate(date = new Date()) {
+            return date.toISOString().split('T')[0];
+        }
 
-    function processCodeBlocks(clone, replacements) {
-        clone.querySelectorAll('pre').forEach(pre => {
-            const { lang, code } = extractCodeBlock(pre);
-            const langClass = lang ? ` class="language-${sanitize(lang)}"` : '';
-            const html = `<pre><code${langClass}>${sanitize(code)}</code></pre>`;
-            pre.replaceWith(document.createTextNode(addReplacement(replacements, html)));
-        });
-    }
+        function sanitizeHtml(value) {
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
 
-    function processMath(clone) {
-        const processed = new Set();
+        function normalizeWhitespace(value) {
+            return String(value ?? '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+        }
 
-        clone.querySelectorAll('annotation[encoding*="tex"]').forEach(annotation => {
-            const tex = annotation.textContent.trim();
-            if (!tex) return;
+        function getClassName(element) {
+            const className = element?.className;
+            if (!className) return '';
+            if (typeof className === 'string') return className;
+            return className.baseVal || '';
+        }
 
-            const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
-            const mathRoot = displayRoot || annotation.closest('.katex, mjx-container, math');
-            if (!mathRoot || processed.has(mathRoot)) return;
+        function queryAll(root, selector) {
+            if (!root || !selector) return [];
 
-            processed.add(mathRoot);
-            mathRoot.replaceWith(document.createTextNode(displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
-        });
-
-        clone.querySelectorAll('script[type^="math/tex"]').forEach(script => {
-            const tex = script.textContent.trim();
-            if (!tex) return;
-            const isDisplay = /mode=display/.test(script.type);
-            script.replaceWith(document.createTextNode(isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
-        });
-    }
-
-    function processMedia(clone) {
-        clone.querySelectorAll('img, canvas, video, audio').forEach(el => {
-            const tag = el.tagName.toLowerCase();
-            const alt = el.getAttribute('alt') || el.getAttribute('aria-label') || '';
-            const label = tag === 'img' && alt ? `[Image: ${alt}]` :
-                tag === 'canvas' ? '[Canvas or chart]' :
-                tag === 'video' ? '[Video]' :
-                tag === 'audio' ? '[Audio]' :
-                '[Media]';
-            el.replaceWith(document.createTextNode(label));
-        });
-    }
-
-    function processLinks(clone, replacements) {
-        clone.querySelectorAll('a[href]').forEach(link => {
-            if (link.closest('pre, code')) return;
-
-            const href = (link.href || '').trim();
-            const lowerHref = href.toLowerCase();
-            if (!href || lowerHref.startsWith('javascript:') || lowerHref.startsWith('data:') || lowerHref.startsWith('vbscript:') || href.startsWith('#')) return;
-
-            const text = link.textContent.replace(/\s+/g, ' ').trim() || href;
-            const html = `<a href="${sanitize(href)}">${sanitize(text)}</a>`;
-            link.replaceWith(document.createTextNode(addReplacement(replacements, html)));
-        });
-    }
-
-    function tableToHtml(table) {
-        const rows = Array.from(table.querySelectorAll('tr'))
-            .map(row => Array.from(row.children)
-                .filter(cell => ['TH', 'TD'].includes(cell.tagName))
-                .map(cell => ({ tag: cell.tagName.toLowerCase(), text: getText(cell).replace(/\s+/g, ' ') })))
-            .filter(cells => cells.length > 0);
-
-        if (rows.length === 0) return sanitize(getText(table));
-
-        const renderedRows = rows.map(cells => {
-            const renderedCells = cells.map(cell => `<${cell.tag}>${sanitize(cell.text)}</${cell.tag}>`).join('');
-            return `<tr>${renderedCells}</tr>`;
-        }).join('');
-
-        return `<table>${renderedRows}</table>`;
-    }
-
-    function processTables(clone, replacements) {
-        clone.querySelectorAll('table').forEach(table => {
-            table.replaceWith(document.createTextNode(addReplacement(replacements, tableToHtml(table))));
-        });
-    }
-
-    function restoreReplacements(html, replacements) {
-        return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), html);
-    }
-
-    function processMessageContent(element) {
-        const clone = element.cloneNode(true);
-        const replacements = [];
-
-        removeUiElements(clone);
-        processCodeBlocks(clone, replacements);
-        processMath(clone);
-        processMedia(clone);
-        processLinks(clone, replacements);
-        processTables(clone, replacements);
-
-        const html = sanitize(getText(clone)).replace(/\n/g, '<br>');
-        return restoreReplacements(html, replacements);
-    }
-
-    function findMessages() {
-        // More specific selectors to avoid nested elements
-        const selectors = [
-            'div[data-message-author-role]', // Modern ChatGPT with clear author role
-            'article[data-testid*="conversation-turn"]', // Conversation turns
-            'div[data-testid="conversation-turn"]', // Specific conversation turn
-            '.group\\/conversation-turn', // Fix for issue #6: More specific selector for conversation turns
-            'div[class*="group"]:not([class*="group"] [class*="group"])', // Top-level groups only
-        ];
-
-        let messages = [];
-        for (const selector of selectors) {
-            messages = document.querySelectorAll(selector);
-            if (messages.length > 0) {
-                console.log(`HTML: Using selector: ${selector}, found ${messages.length} messages`);
-                break;
+            try {
+                return Array.from(root.querySelectorAll(selector));
+            } catch (error) {
+                console.warn('[Chat Exporter] Selector failed:', selector, error);
+                return [];
             }
         }
 
-        if (messages.length === 0) {
-            // Fallback: try to find conversation container and parse its structure
-            const conversationContainer = document.querySelector('[role="main"], main, .conversation, [class*="conversation"]');
-            if (conversationContainer) {
-                // Look for direct children that seem like message containers
-                messages = conversationContainer.querySelectorAll(':scope > div, :scope > article');
-                console.log(`HTML: Fallback: found ${messages.length} potential messages in conversation container`);
+        function matches(element, selector) {
+            if (!element || !selector || typeof element.matches !== 'function') return false;
+
+            try {
+                return element.matches(selector);
+            } catch (error) {
+                return false;
             }
         }
 
-        // Filter and validate messages
-        const validMessages = Array.from(messages).filter(msg => {
-            const text = msg.textContent.trim();
-            
-            // Must have substantial content
-            if (text.length < 30) return false;
-            if (text.length > 100000) return false;
-            
-            // Skip elements that are clearly UI components
-            if (msg.querySelector('input[type="text"], textarea')) return false;
-            if (msg.classList.contains('typing') || msg.classList.contains('loading')) return false;
-            
-            // Must contain meaningful content (not just buttons/UI)
-            const meaningfulText = text.replace(/\s+/g, ' ').trim();
-            if (meaningfulText.split(' ').length < 5) return false;
-            
-            return true;
-        });
+        function getText(element) {
+            if (!element) return '';
+            const innerText = typeof element.innerText === 'string' ? element.innerText : '';
+            return (innerText || element.textContent || '').replace(/\u00a0/g, ' ').trim();
+        }
 
-        // Remove nested messages and consolidate content
-        const consolidatedMessages = [];
-        const usedElements = new Set();
+        function collectTextWithBreaks(node) {
+            if (!node) return '';
 
-        validMessages.forEach(msg => {
-            if (usedElements.has(msg)) return;
-            
-            // Check if this message is nested within another valid message
-            const isNested = validMessages.some(other => 
-                other !== msg && other.contains(msg) && !usedElements.has(other)
-            );
-            
-            if (!isNested) {
-                consolidatedMessages.push(msg);
-                usedElements.add(msg);
+            if (node.nodeType === 3) {
+                return node.nodeValue || '';
             }
-        });
 
-        return consolidatedMessages;
-    }
-
-    function identifySender(messageElement, index, allMessages) {
-        // Method 1: Check for data attributes (most reliable)
-        const authorRole = messageElement.getAttribute('data-message-author-role');
-        if (authorRole) {
-            return authorRole === 'user' ? 'You' : 'ChatGPT';
-        }
-
-        // Method 2: Look for avatar images with better detection
-        const avatars = messageElement.querySelectorAll('img');
-        for (const avatar of avatars) {
-            const alt = avatar.alt?.toLowerCase() || '';
-            const src = avatar.src?.toLowerCase() || '';
-            const classes = avatar.className?.toLowerCase() || '';
-            
-            // User indicators
-            if (alt.includes('user') || src.includes('user') || classes.includes('user')) {
-                return 'You';
+            if (node.nodeType !== 1) {
+                return '';
             }
-            
-            // Assistant indicators
-            if (alt.includes('chatgpt') || alt.includes('assistant') || alt.includes('gpt') || 
-                src.includes('assistant') || src.includes('chatgpt') || classes.includes('assistant')) {
-                return 'ChatGPT';
+
+            const tag = node.tagName.toLowerCase();
+            if (tag === 'br') return '\n';
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+
+            const before = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+            const after = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+            return before + Array.from(node.childNodes).map(collectTextWithBreaks).join('') + after;
+        }
+
+        function getCodeText(element) {
+            if (!element) return '';
+
+            if (typeof element.innerText === 'string' && element.innerText.trim()) {
+                return element.innerText.replace(/\u00a0/g, ' ').replace(/\n{3,}/g, '\n\n').trimEnd();
             }
+
+            const clone = element.cloneNode(true);
+            queryAll(clone, 'br').forEach(br => br.replaceWith(clone.ownerDocument.createTextNode('\n')));
+            return collectTextWithBreaks(clone).replace(/\n{3,}/g, '\n\n').trimEnd();
         }
 
-        // Method 3: Content analysis with better patterns
-        const text = messageElement.textContent.toLowerCase();
-        const textStart = text.substring(0, 200); // Look at beginning of message
-        
-        // Strong ChatGPT indicators
-        if (textStart.match(/^(i understand|i can help|here's|i'll|let me|i'd be happy|certainly|of course)/)) {
-            return 'ChatGPT';
-        }
-        
-        // Strong user indicators  
-        if (textStart.match(/^(can you|please help|how do i|i need|i want|help me|could you)/)) {
-            return 'You';
+        function normalizeCodeText(value) {
+            return String(value ?? '')
+                .replace(/\r\n?/g, '\n')
+                .replace(/^\n+/, '')
+                .replace(/\n+$/, '');
         }
 
-        // Method 4: Structural analysis - look at DOM structure
-        const hasCodeBlocks = messageElement.querySelectorAll('pre, code').length > 0;
-        const hasLongText = messageElement.textContent.length > 200;
-        const hasLists = messageElement.querySelectorAll('ul, ol, li').length > 0;
-        
-        // ChatGPT messages tend to be longer and more structured
-        if (hasCodeBlocks && hasLongText && hasLists) {
-            return 'ChatGPT';
+        function createTextNode(reference, text) {
+            return reference.ownerDocument.createTextNode(text);
         }
 
-        // Method 5: Position-based fallback with better logic
-        // Try to detect actual alternating pattern by looking at content characteristics
-        if (index > 0 && allMessages[index - 1]) {
-            const prevText = allMessages[index - 1].textContent;
-            const currentText = messageElement.textContent;
-            
-            // If previous was short and current is long, likely user -> assistant
-            if (prevText.length < 100 && currentText.length > 300) {
-                return 'ChatGPT';
-            }
-            
-            // If previous was long and current is short, likely assistant -> user  
-            if (prevText.length > 300 && currentText.length < 100) {
-                return 'You';
-            }
+        function addReplacement(replacements, html) {
+            const marker = `${MARKER_PREFIX}${replacements.length}__`;
+            replacements.push({ marker, html });
+            return marker;
         }
 
-        // Final fallback
-        return index % 2 === 0 ? 'You' : 'ChatGPT';
-    }
+        function restoreReplacements(value, replacements) {
+            return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), value);
+        }
 
-    function extractConversationTitle() {
-        // Try to get actual conversation title
-        const titleSelectors = [
-            'h1:not([class*="hidden"])',
-            '[class*="conversation-title"]',
-            '[data-testid*="conversation-title"]',
-            'title'
-        ];
+        function cleanMarkdown(markdown) {
+            return String(markdown ?? '')
+                .split(/(```[\s\S]*?```)/g)
+                .map(part => part.startsWith('```')
+                    ? part
+                    : part
+                        .replace(/[ \t]+\n/g, '\n')
+                        .replace(/\n[ \t]+/g, '\n')
+                        .replace(/\n{3,}/g, '\n\n')
+                        .replace(/&lt;/g, '<')
+                        .replace(/&gt;/g, '>')
+                        .replace(/&amp;/g, '&'))
+                .join('')
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+        }
 
-        for (const selector of titleSelectors) {
-            const element = document.querySelector(selector);
-            if (element && element.textContent.trim()) {
-                const title = element.textContent.trim();
-                // Avoid generic titles
-                if (!['chatgpt', 'new chat', 'untitled', 'chat'].includes(title.toLowerCase())) {
-                    return title;
+        function escapeMarkdownLinkText(value) {
+            return String(value ?? '')
+                .replace(/\\/g, '\\\\')
+                .replace(/([\[\]])/g, '\\$1');
+        }
+
+        function escapeMarkdownUrl(value) {
+            return String(value ?? '')
+                .replace(/\\/g, '%5C')
+                .replace(/\)/g, '%29');
+        }
+
+        function isUnsafeHref(href) {
+            const lower = String(href || '').trim().toLowerCase();
+            return !lower ||
+                lower.startsWith('javascript:') ||
+                lower.startsWith('data:') ||
+                lower.startsWith('vbscript:') ||
+                lower.startsWith('#');
+        }
+
+        function topLevelElements(elements) {
+            return elements.filter(element => !elements.some(other => other !== element && other.contains(element)));
+        }
+
+        function removeUiElements(clone) {
+            const uiSelector = [
+                'button',
+                'svg',
+                'style',
+                'script',
+                'textarea',
+                'input',
+                '[contenteditable="true"]',
+                '[class*="regenerate"]',
+                '[class*="copy-button"]',
+                '[data-testid*="copy"]',
+                '[data-test-id*="copy"]',
+                '[aria-label*="Copy"]',
+                '[aria-label*="copy"]',
+                '[aria-label*="More"]',
+                '[aria-label*="more"]'
+            ].join(',');
+
+            queryAll(clone, uiSelector).forEach(element => element.remove());
+        }
+
+        function detectLanguage(block) {
+            const codeElement = matches(block, 'code') ? block : block.querySelector('code');
+            const sources = [
+                codeElement?.className,
+                block.getAttribute?.('data-language'),
+                block.getAttribute?.('language'),
+                block.getAttribute?.('lang'),
+                codeElement?.getAttribute?.('data-language'),
+                codeElement?.getAttribute?.('language'),
+                codeElement?.getAttribute?.('lang'),
+                block.getAttribute?.('aria-label')
+            ].filter(Boolean).map(String);
+
+            for (const source of sources) {
+                const languageMatch = source.match(/language-([a-zA-Z0-9_+#.-]+)/);
+                if (languageMatch) return languageMatch[1].toLowerCase();
+                if (/^[a-zA-Z0-9_+#.-]{1,24}$/.test(source) && !/^(code|copy|download)$/i.test(source)) {
+                    return source.toLowerCase();
                 }
             }
-        }
 
-        return 'ChatGPT Conversation';
-    }
-
-    function extractFormattedContent() {
-        const messages = findMessages();
-        
-        if (messages.length === 0) {
-            console.log('HTML: No messages found. The page structure may have changed.');
-            return '<div class="message"><div class="content">No messages found.</div></div>';
-        }
-
-        console.log(`HTML: Processing ${messages.length} messages...`);
-
-        // Process messages with better duplicate detection
-        const processedMessages = [];
-        const seenContent = new Set();
-
-        messages.forEach((messageElement, index) => {
-            const sender = identifySender(messageElement, index, messages);
-            const cleanText = processMessageContent(messageElement);
-            
-            // Skip if empty or too short
-            if (!cleanText || cleanText.replace(/<[^>]*>/g, '').trim().length < 30) {
-                console.log(`HTML: Skipping message ${index}: too short or empty`);
-                return;
+            const header = block.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code"], [data-test-id*="code"], .code-language, .code-lang, [slot="header"]');
+            const headerText = normalizeWhitespace(getText(header)).replace(/\b(copy|code|download)\b/gi, '').trim();
+            if (headerText && headerText.length < 32 && !headerText.includes('\n')) {
+                return headerText.toLowerCase();
             }
 
-            // Create a content hash for duplicate detection
-            const contentHash = cleanText.substring(0, 100).replace(/\s+/g, ' ').trim();
-            if (seenContent.has(contentHash)) {
-                console.log(`HTML: Skipping message ${index}: duplicate content`);
-                return;
-            }
-            seenContent.add(contentHash);
+            return '';
+        }
 
-            processedMessages.push({
-                sender,
-                content: cleanText,
-                originalIndex: index
+        function extractCodeBlock(block) {
+            const clone = block.cloneNode(true);
+            const language = detectLanguage(clone);
+
+            queryAll(clone, 'button, svg, [aria-label*="Copy"], [aria-label*="copy"], [class*="sticky"], [class*="code-header"], [data-testid*="copy"], [data-test-id*="copy"], [slot="header"]').forEach(element => element.remove());
+
+            const cmContent = clone.querySelector('.cm-content');
+            if (cmContent) {
+                const cmLines = queryAll(cmContent, '.cm-line');
+                if (cmLines.length > 0) {
+                    return {
+                        lang: language,
+                        code: normalizeCodeText(cmLines.map(line => line.textContent || '').join('\n'))
+                    };
+                }
+
+                return {
+                    lang: language,
+                    code: normalizeCodeText(getCodeText(cmContent))
+                };
+            }
+
+            const codeElement = matches(clone, 'code') ? clone : clone.querySelector('code');
+            return {
+                lang: language,
+                code: normalizeCodeText(getCodeText(codeElement || clone))
+            };
+        }
+
+        function formatCodeBlock(block, format, replacements) {
+            const { lang, code } = extractCodeBlock(block);
+
+            if (format === 'markdown') {
+                return `\n\n\`\`\`${lang}\n${code}\n\`\`\`\n\n`;
+            }
+
+            const langClass = lang ? ` class="language-${sanitizeHtml(lang)}"` : '';
+            if (format === 'pdf') {
+                const label = lang ? `<div class="code-language">${sanitizeHtml(lang)}</div>` : '';
+                return addReplacement(replacements, `<pre class="code-block">${label}<code>${sanitizeHtml(code)}</code></pre>`);
+            }
+
+            return addReplacement(replacements, `<pre><code${langClass}>${sanitizeHtml(code)}</code></pre>`);
+        }
+
+        function processCodeBlocks(clone, format, replacements) {
+            const blocks = topLevelElements(queryAll(clone, 'pre, code-block, [data-testid*="code-block"], [data-test-id*="code-block"]'));
+
+            blocks.forEach(block => {
+                const replacement = formatCodeBlock(block, format, replacements);
+                block.replaceWith(createTextNode(block, replacement));
             });
-        });
+        }
 
-        // Apply sender sequence correction
-        for (let i = 1; i < processedMessages.length; i++) {
-            const current = processedMessages[i];
-            const previous = processedMessages[i - 1];
-            
-            // If we have two consecutive messages from the same sender, try to fix it
-            if (current.sender === previous.sender) {
-                // Use content analysis to determine which should be flipped
-                const currentLength = current.content.length;
-                const previousLength = previous.content.length;
-                
-                // If current message is much longer, it's likely ChatGPT
-                if (currentLength > previousLength * 2 && currentLength > 500) {
-                    current.sender = 'ChatGPT';
-                } else if (previousLength > currentLength * 2 && previousLength > 500) {
-                    previous.sender = 'ChatGPT';
-                    current.sender = 'You';
-                } else {
-                    // Default alternating fix
-                    current.sender = current.sender === 'You' ? 'ChatGPT' : 'You';
-                }
-                
-                console.log(`HTML: Fixed consecutive ${previous.sender} messages at positions ${i-1} and ${i}`);
+        function processMath(clone) {
+            const processed = new Set();
+
+            queryAll(clone, 'annotation').forEach(annotation => {
+                const encoding = (annotation.getAttribute('encoding') || '').toLowerCase();
+                if (!encoding.includes('tex') && !encoding.includes('latex')) return;
+
+                const tex = annotation.textContent.trim();
+                if (!tex) return;
+
+                const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
+                const mathRoot = displayRoot || annotation.closest('.katex') || annotation.closest('mjx-container') || annotation.closest('math');
+                if (!mathRoot || processed.has(mathRoot)) return;
+
+                processed.add(mathRoot);
+                mathRoot.replaceWith(createTextNode(mathRoot, displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+            });
+
+            queryAll(clone, 'script[type^="math/tex"]').forEach(script => {
+                const tex = script.textContent.trim();
+                if (!tex) return;
+                const isDisplay = /mode=display/.test(script.type);
+                script.replaceWith(createTextNode(script, isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+            });
+        }
+
+        function processMedia(clone, format, replacements) {
+            queryAll(clone, 'img, canvas, video, audio').forEach(element => {
+                const tag = element.tagName.toLowerCase();
+                const alt = normalizeWhitespace(element.getAttribute('alt') || element.getAttribute('aria-label') || element.getAttribute('title') || '');
+                const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                    tag === 'img' ? '[Image]' :
+                    tag === 'canvas' ? '[Canvas or chart]' :
+                    tag === 'video' ? '[Video]' :
+                    tag === 'audio' ? '[Audio]' :
+                    '[Media]';
+
+                const replacement = format === 'markdown'
+                    ? label
+                    : addReplacement(replacements, `<span class="media-placeholder">${sanitizeHtml(label)}</span>`);
+                element.replaceWith(createTextNode(element, replacement));
+            });
+        }
+
+        function processLinks(clone, format, replacements) {
+            queryAll(clone, 'a[href]').forEach(link => {
+                if (link.closest('pre, code, code-block')) return;
+
+                const href = String(link.href || link.getAttribute('href') || '').trim();
+                if (isUnsafeHref(href)) return;
+
+                const text = normalizeWhitespace(link.textContent) || href;
+                const replacement = format === 'markdown'
+                    ? `[${escapeMarkdownLinkText(text)}](${escapeMarkdownUrl(href)})`
+                    : addReplacement(replacements, `<a href="${sanitizeHtml(href)}">${sanitizeHtml(text)}</a>`);
+
+                link.replaceWith(createTextNode(link, replacement));
+            });
+        }
+
+        function tableCellText(cell) {
+            return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+        }
+
+        function tableToMarkdown(table) {
+            const rows = queryAll(table, 'tr')
+                .map(row => Array.from(row.children)
+                    .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                    .map(tableCellText))
+                .filter(row => row.length > 0);
+
+            if (rows.length === 0) return normalizeWhitespace(getText(table));
+
+            const width = Math.max(...rows.map(row => row.length));
+            const normalizedRows = rows.map(row => row.concat(Array(Math.max(0, width - row.length)).fill(' ')));
+            const header = normalizedRows[0];
+            const separator = header.map(() => '---');
+            const body = normalizedRows.slice(1);
+
+            return [
+                `| ${header.join(' | ')} |`,
+                `| ${separator.join(' | ')} |`,
+                ...body.map(row => `| ${row.join(' | ')} |`)
+            ].join('\n');
+        }
+
+        function tableToHtml(table) {
+            const rows = queryAll(table, 'tr')
+                .map(row => Array.from(row.children)
+                    .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                    .map(cell => ({
+                        tag: cell.tagName.toLowerCase(),
+                        text: normalizeWhitespace(getText(cell))
+                    })))
+                .filter(row => row.length > 0);
+
+            if (rows.length === 0) return sanitizeHtml(getText(table));
+
+            return `<table>${rows.map(row => {
+                const cells = row.map(cell => `<${cell.tag}>${sanitizeHtml(cell.text)}</${cell.tag}>`).join('');
+                return `<tr>${cells}</tr>`;
+            }).join('')}</table>`;
+        }
+
+        function processTables(clone, format, replacements) {
+            topLevelElements(queryAll(clone, 'table')).forEach(table => {
+                const replacement = format === 'markdown'
+                    ? `\n\n${tableToMarkdown(table)}\n\n`
+                    : addReplacement(replacements, tableToHtml(table));
+                table.replaceWith(createTextNode(table, replacement));
+            });
+        }
+
+        function cardSignal(element) {
+            const pieces = [
+                element.tagName,
+                getClassName(element),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id'),
+                element.getAttribute('aria-label'),
+                element.getAttribute('role')
+            ].filter(Boolean).join(' ').toLowerCase();
+
+            if (/\b(artifact|canvas-preview|generated-file|download-card|attachment|file-card)\b/.test(pieces)) {
+                return pieces.includes('artifact') || pieces.includes('canvas-preview') ? 'Artifact' : 'File';
             }
+
+            if (/(^|[\s_-])(attachment|file)([\s_-]|$)/.test(pieces)) {
+                return 'File';
+            }
+
+            return '';
         }
 
-        // Generate HTML output
-        let html = '';
-        processedMessages.forEach(({ sender, content }) => {
-            html += `
-                <div class="message">
-                    <div class="sender">${sender}</div>
-                    <div class="content">${content}</div>
-                </div>
-            `;
-        });
+        function cardLabel(element) {
+            const candidates = [
+                element.getAttribute('aria-label'),
+                element.getAttribute('title'),
+                element.getAttribute('download'),
+                element.getAttribute('data-filename'),
+                getText(element)
+            ].filter(Boolean).map(normalizeWhitespace);
 
-        console.log(`HTML: Export completed: ${processedMessages.length} messages exported`);
-        return html;
-    }
+            const label = candidates.find(value => value && value.length <= 180) || '';
+            return label
+                .replace(/\b(open|download|preview|file|attachment|artifact)\b/gi, ' ')
+                .replace(/\s+/g, ' ')
+                .trim();
+        }
 
-    const date = formatDate();
-    const source = window.location.href;
-    const title = extractConversationTitle();
-    const conversationHTML = extractFormattedContent();
+        function processCards(clone, format, replacements) {
+            const cards = topLevelElements(Array.from(clone.querySelectorAll('*')).filter(element => {
+                const kind = cardSignal(element);
+                if (!kind) return false;
+                if (matches(element, '[data-message-author-role], user-query, model-response')) return false;
+                if (element.closest('pre, code, code-block, table')) return false;
+                if (element.querySelector('pre, code-block, table, user-query, model-response')) return false;
 
-    const html = `
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>${title} - ${date}</title>
-    <style>
-        body {
-            font-family: 'Segoe UI', sans-serif;
-            max-width: 800px;
-            margin: auto;
-            padding: 2rem;
-            background: #fff;
-            color: #333;
-            line-height: 1.6;
+                const text = normalizeWhitespace(getText(element));
+                const label = cardLabel(element);
+                return Boolean(label || text) && text.length <= 240;
+            }));
+
+            cards.forEach(card => {
+                const kind = cardSignal(card);
+                const label = cardLabel(card);
+                const text = label ? `[${kind}: ${label}]` : `[${kind}]`;
+                const replacement = format === 'markdown'
+                    ? text
+                    : addReplacement(replacements, `<span class="card-placeholder">${sanitizeHtml(text)}</span>`);
+                card.replaceWith(createTextNode(card, replacement));
+            });
         }
-        .header {
-            text-align: center;
-            margin-bottom: 2rem;
-            padding-bottom: 1rem;
-            border-bottom: 2px solid #eee;
+
+        function serializeMarkdownChildren(element, context = {}) {
+            return Array.from(element.childNodes).map((node, index) => serializeMarkdownNode(node, {
+                ...context,
+                index
+            })).join('');
         }
-        .header h1 {
-            color: #2c3e50;
-            margin-bottom: 0.5rem;
+
+        function serializeMarkdownNode(node, context = {}) {
+            if (node.nodeType === 3) {
+                const value = node.nodeValue || '';
+                if (value.includes('```') || value.includes('| ---') || value.includes(MARKER_PREFIX) || value.match(/^\s*\[[^\]]+\]/)) {
+                    return value;
+                }
+                return value.replace(/[ \t\r\n]+/g, ' ');
+            }
+
+            if (node.nodeType !== 1) return '';
+
+            const tag = node.tagName.toLowerCase();
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+            if (tag === 'br') return '\n';
+
+            if (/^h[1-6]$/.test(tag)) {
+                const level = Number(tag.slice(1));
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${'#'.repeat(level)} ${content}\n\n` : '';
+            }
+
+            if (tag === 'p') {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${content}\n\n` : '';
+            }
+
+            if (tag === 'blockquote') {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${content.split('\n').map(line => `> ${line.trim()}`).join('\n')}\n\n` : '';
+            }
+
+            if (tag === 'ul' || tag === 'ol') {
+                const children = Array.from(node.children).filter(child => child.tagName && child.tagName.toLowerCase() === 'li');
+                return `\n${children.map((child, index) => serializeMarkdownNode(child, {
+                    ...context,
+                    listType: tag,
+                    index,
+                    depth: (context.depth || 0)
+                })).join('')}\n`;
+            }
+
+            if (tag === 'li') {
+                const depth = context.depth || 0;
+                const marker = context.listType === 'ol' ? `${(context.index || 0) + 1}. ` : '- ';
+                const indent = '  '.repeat(depth);
+                const content = serializeMarkdownChildren(node, {
+                    ...context,
+                    depth: depth + 1
+                }).trim();
+                return content ? `${indent}${marker}${content.replace(/\n+/g, `\n${indent}  `)}\n` : '';
+            }
+
+            if (['strong', 'b'].includes(tag)) {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `**${content}**` : '';
+            }
+
+            if (['em', 'i'].includes(tag)) {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `*${content}*` : '';
+            }
+
+            if (tag === 'code') {
+                const content = getCodeText(node).replace(/`/g, '\\`').trim();
+                return content ? `\`${content}\`` : '';
+            }
+
+            const content = serializeMarkdownChildren(node, context);
+            if (['div', 'section', 'article', 'main', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+                return content;
+            }
+
+            return content;
         }
-        .metadata {
-            color: #666;
-            font-size: 0.9rem;
+
+        function serializeHtmlChildren(element, replacements) {
+            return Array.from(element.childNodes).map(node => serializeHtmlNode(node, replacements)).join('');
         }
-        .message {
-            margin-bottom: 1.5rem;
-            padding: 1rem;
-            border-radius: 8px;
-            background: #f8f9fa;
+
+        function serializeHtmlNode(node, replacements) {
+            if (node.nodeType === 3) {
+                return sanitizeHtml(node.nodeValue || '');
+            }
+
+            if (node.nodeType !== 1) return '';
+
+            const tag = node.tagName.toLowerCase();
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+            if (tag === 'br') return '<br>';
+
+            const content = serializeHtmlChildren(node, replacements);
+            const blockTags = new Set(['p', 'ul', 'ol', 'li', 'blockquote', 'strong', 'b', 'em', 'i']);
+
+            if (/^h[1-6]$/.test(tag)) {
+                return `<${tag}>${content}</${tag}>`;
+            }
+
+            if (blockTags.has(tag)) {
+                const safeTag = tag === 'b' ? 'strong' : tag === 'i' ? 'em' : tag;
+                return `<${safeTag}>${content}</${safeTag}>`;
+            }
+
+            if (tag === 'code') {
+                return `<code>${sanitizeHtml(getCodeText(node).trim())}</code>`;
+            }
+
+            if (['div', 'section', 'article', 'main', 'span', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+                return content;
+            }
+
+            return content;
         }
-        .sender {
-            font-weight: bold;
-            color: #2c3e50;
-            margin-bottom: 0.5rem;
-            font-size: 1.1rem;
+
+        function serializeMessageContent(element, format) {
+            const clone = element.cloneNode(true);
+            const replacements = [];
+
+            removeUiElements(clone);
+            processCards(clone, format, replacements);
+            processCodeBlocks(clone, format, replacements);
+            processMath(clone);
+            processMedia(clone, format, replacements);
+            processLinks(clone, format, replacements);
+            processTables(clone, format, replacements);
+
+            if (format === 'markdown') {
+                return cleanMarkdown(serializeMarkdownChildren(clone));
+            }
+
+            const html = serializeHtmlChildren(clone, replacements)
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+            return restoreReplacements(html, replacements);
         }
-        .content {
-            white-space: pre-wrap;
-            word-wrap: break-word;
+
+        function detectProvider(doc) {
+            const url = doc.defaultView?.location?.href || '';
+            if (/gemini\.google\.com/i.test(url) || doc.querySelector('user-query, model-response')) return 'gemini';
+            return 'chatgpt';
         }
-        pre {
-            background: #f4f4f4;
-            padding: 1rem;
-            border-radius: 4px;
-            overflow-x: auto;
-            border-left: 4px solid #007acc;
+
+        function providerFor(providerName, doc) {
+            const id = providerName || detectProvider(doc);
+            return PROVIDERS[id] || PROVIDERS.chatgpt;
         }
-        code {
-            font-family: 'Consolas', 'Monaco', monospace;
-            font-size: 0.9rem;
+
+        function meaningfulScore(element) {
+            const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+            return normalizeWhitespace(element.textContent).length + richCount * 200;
         }
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            margin: 1rem 0;
+
+        function isValidMessage(element) {
+            const text = normalizeWhitespace(element.textContent);
+            const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+
+            if (text.length < 5 && richCount === 0) return false;
+            if (text.length > 200000) return false;
+            if (matches(element, 'nav, aside, header, footer, form, menu')) return false;
+            if (element.querySelector('textarea, input[type="text"], [contenteditable="true"]') && !element.hasAttribute('data-message-author-role')) return false;
+            if (getClassName(element).match(/\b(typing|loading|spinner)\b/i)) return false;
+
+            return true;
         }
-        th, td {
-            border: 1px solid #d9dde3;
-            padding: 0.5rem;
-            text-align: left;
-            vertical-align: top;
+
+        function findMessages(doc, provider) {
+            for (const selector of provider.messageSelectors) {
+                const messages = topLevelElements(queryAll(doc, selector)).filter(isValidMessage);
+                if (messages.length > 0) {
+                    console.log(`[Chat Exporter] ${provider.id}: using selector "${selector}" (${messages.length} messages)`);
+                    return messages;
+                }
+            }
+
+            const container = doc.querySelector('[role="main"], main, [class*="conversation"], [class*="chat"]');
+            if (!container) return [];
+
+            return topLevelElements(queryAll(container, ':scope > article, :scope > section, :scope > div')).filter(isValidMessage);
         }
-        th {
-            background: #eef2f7;
+
+        function selectContentRoot(messageElement, provider) {
+            const candidates = [messageElement];
+
+            provider.contentSelectors.forEach(selector => {
+                if (matches(messageElement, selector)) candidates.push(messageElement);
+                candidates.push(...queryAll(messageElement, selector));
+            });
+
+            return candidates
+                .filter(Boolean)
+                .sort((a, b) => meaningfulScore(b) - meaningfulScore(a))[0] || messageElement;
         }
-        @media print {
-            body { margin: 0; padding: 1rem; }
-            .message { break-inside: avoid; }
+
+        function identifySender(element, index, provider) {
+            const tag = element.tagName.toLowerCase();
+            if (tag === 'user-query') return { sender: 'You', reliable: true };
+            if (tag === 'model-response') return { sender: provider.assistantName, reliable: true };
+
+            const role = element.getAttribute('data-message-author-role') || element.getAttribute('data-author') || element.getAttribute('data-sender');
+            if (role) {
+                const normalizedRole = role.toLowerCase();
+                if (normalizedRole === 'user') return { sender: 'You', reliable: true };
+                if (['assistant', 'model', 'bot', 'chatgpt', 'gemini'].includes(normalizedRole)) {
+                    return { sender: provider.assistantName, reliable: true };
+                }
+            }
+
+            const classAndAttrs = [
+                getClassName(element),
+                element.getAttribute('aria-label'),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id')
+            ].filter(Boolean).join(' ').toLowerCase();
+
+            if (classAndAttrs.match(/\b(user|human|query)\b/)) return { sender: 'You', reliable: false };
+            if (classAndAttrs.match(/\b(assistant|model|response|chatgpt|gemini|bard)\b/)) return { sender: provider.assistantName, reliable: false };
+
+            const textStart = normalizeWhitespace(element.textContent).slice(0, 220).toLowerCase();
+            if (/^(i understand|i can help|here's|i'll|let me|i'd be happy|certainly|of course|absolutely)/.test(textStart)) {
+                return { sender: provider.assistantName, reliable: false };
+            }
+
+            if (/^(can you|please help|how do i|i need|i want|help me|could you|explain|what is)/.test(textStart)) {
+                return { sender: 'You', reliable: false };
+            }
+
+            return { sender: index % 2 === 0 ? 'You' : provider.assistantName, reliable: false };
         }
-    </style>
-</head>
-<body>
-    <div class="header">
-        <h1>${title}</h1>
-        <div class="metadata">
-            <div><strong>Date:</strong> ${date}</div>
-            <div><strong>Source:</strong> <a href="${source}">chat.openai.com</a></div>
+
+        function contentHash(content) {
+            return normalizeWhitespace(String(content || '').replace(/<[^>]+>/g, ' ')).slice(0, 160);
+        }
+
+        function extractConversation(options = {}) {
+            const doc = resolveDocument(options.document);
+            const provider = providerFor(options.provider, doc);
+            const format = options.format || 'markdown';
+            const rawMessages = findMessages(doc, provider);
+            const seen = new Set();
+            const messages = [];
+
+            rawMessages.forEach((messageElement, index) => {
+                const contentRoot = selectContentRoot(messageElement, provider);
+                const content = serializeMessageContent(contentRoot, format);
+                const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
+
+                if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+
+                const hash = contentHash(content);
+                if (seen.has(hash)) return;
+                seen.add(hash);
+
+                const sender = identifySender(messageElement, index, provider);
+                messages.push({
+                    sender: sender.sender,
+                    senderType: sender.sender === 'You' ? 'user' : 'assistant',
+                    reliableSender: sender.reliable,
+                    content,
+                    index
+                });
+            });
+
+            return {
+                version: ENGINE_VERSION,
+                provider: provider.id,
+                providerLabel: provider.assistantName,
+                sourceLabel: provider.sourceLabel,
+                title: extractConversationTitle(doc, provider),
+                sourceUrl: doc.defaultView?.location?.href || '',
+                date: formatDate(options.date || new Date()),
+                messages
+            };
+        }
+
+        function extractConversationTitle(doc, provider) {
+            for (const selector of provider.titleSelectors) {
+                const element = doc.querySelector(selector);
+                const title = normalizeWhitespace(element?.textContent);
+                if (title && !provider.genericTitlePattern.test(title)) return title;
+            }
+
+            const docTitle = normalizeWhitespace(doc.title);
+            if (docTitle && !provider.genericTitlePattern.test(docTitle)) return docTitle;
+
+            return provider.defaultTitle;
+        }
+
+        function renderMarkdown(conversation) {
+            const lines = [
+                `# ${conversation.title}\n`,
+                `**Date:** ${conversation.date}`,
+                `**Source:** [${conversation.sourceLabel}](${conversation.sourceUrl})\n`,
+                '---\n'
+            ];
+
+            conversation.messages.forEach(message => {
+                lines.push(`### **${message.sender}**\n`, message.content, '\n---\n');
+            });
+
+            return `${lines.join('\n').trim()}\n`;
+        }
+
+        function renderHtmlDocument(conversation, options = {}) {
+            const isPdf = options.format === 'pdf';
+            const source = sanitizeHtml(conversation.sourceUrl);
+            const title = sanitizeHtml(conversation.title);
+            const messages = conversation.messages.map(message => {
+                const senderClass = message.senderType === 'user' ? 'user' : 'assistant';
+                return `
+            <div class="message ${senderClass}">
+                <div class="sender">${sanitizeHtml(message.sender)}</div>
+                <div class="content">${message.content}</div>
+            </div>`;
+            }).join('');
+
+            const pdfInstructions = isPdf ? `
+        <div class="instructions no-print">
+            <h3>Convert to PDF</h3>
+            <ol>
+                <li>Press Ctrl+P on Windows/Linux or Cmd+P on Mac.</li>
+                <li>Set Destination to Save as PDF.</li>
+                <li>Choose your preferred page size.</li>
+                <li>Click Save.</li>
+            </ol>
+            <p><em>This instruction box will not appear in the PDF.</em></p>
+        </div>` : '';
+
+            return `<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <title>${title} - ${conversation.date}</title>
+        <style>
+            @media print {
+                body { margin: 0; }
+                .no-print { display: none; }
+                .message { page-break-inside: avoid; }
+            }
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+                max-width: 840px;
+                margin: auto;
+                padding: 2rem;
+                background: #fff;
+                color: #333;
+                line-height: 1.6;
+            }
+            .header {
+                text-align: center;
+                margin-bottom: 2rem;
+                padding-bottom: 1rem;
+                border-bottom: 2px solid #eee;
+            }
+            .metadata {
+                color: #666;
+                font-size: 0.9rem;
+            }
+            .message {
+                margin-bottom: 1.5rem;
+                padding: 1rem;
+                border-radius: 8px;
+                background: #f8f9fa;
+            }
+            .message.user {
+                background: #eaf4ff;
+            }
+            .sender {
+                font-weight: 700;
+                color: #2c3e50;
+                margin-bottom: 0.5rem;
+            }
+            .content {
+                white-space: pre-wrap;
+                overflow-wrap: anywhere;
+            }
+            pre {
+                background: #f4f4f4;
+                padding: 1rem;
+                border-radius: 4px;
+                overflow-x: auto;
+                border-left: 4px solid #007acc;
+            }
+            .code-block {
+                background: #282c34;
+                color: #abb2bf;
+                border-left: 0;
+            }
+            .code-block code {
+                white-space: pre;
+            }
+            .code-language {
+                color: #d7dae0;
+                font-size: 12px;
+                margin-bottom: 8px;
+                text-transform: uppercase;
+            }
+            code {
+                font-family: Consolas, Monaco, "Courier New", monospace;
+                font-size: 0.92rem;
+            }
+            table {
+                width: 100%;
+                border-collapse: collapse;
+                margin: 1rem 0;
+            }
+            th, td {
+                border: 1px solid #d9dde3;
+                padding: 0.5rem;
+                text-align: left;
+                vertical-align: top;
+            }
+            th {
+                background: #eef2f7;
+            }
+            .instructions {
+                background: #fff8dc;
+                border: 1px solid #e3c565;
+                border-radius: 8px;
+                padding: 1rem;
+                margin-bottom: 1.5rem;
+            }
+        </style>
+    </head>
+    <body>
+        ${pdfInstructions}
+        <div class="header">
+            <h1>${title}</h1>
+            <div class="metadata">
+                <div><strong>Date:</strong> ${sanitizeHtml(conversation.date)}</div>
+                <div><strong>Source:</strong> <a href="${source}">${sanitizeHtml(conversation.sourceLabel)}</a></div>
+                <div><strong>Messages:</strong> ${conversation.messages.length}</div>
+            </div>
         </div>
-    </div>
-    
-    <div class="conversation">
-        ${conversationHTML}
-    </div>
-</body>
-</html>`;
+        <div class="conversation">${messages}
+        </div>
+    </body>
+    </html>`;
+        }
 
-    const blob = new Blob([html], { type: 'text/html' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    // Use document title for better file naming (Issue #12)
-    const safeTitle = document.title.replace(/[<>:"/\\|?*]/g, '').replace(/\s+/g, ' ').trim();
-    a.download = safeTitle ? `${safeTitle} (${date}).html` : `ChatGPT_Conversation_${date}.html`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+        function render(conversation, format) {
+            if (format === 'markdown') return renderMarkdown(conversation);
+            if (format === 'pdf') return renderHtmlDocument(conversation, { format: 'pdf' });
+            if (format === 'html') return renderHtmlDocument(conversation, { format: 'html' });
+            throw new Error(`Unsupported export format: ${format}`);
+        }
+
+        function filenameFor(conversation, format, doc) {
+            const safeTitle = normalizeWhitespace(doc.title || conversation.title)
+                .replace(/[<>:"/\\|?*]/g, '')
+                .slice(0, 120);
+
+            if (format === 'markdown') {
+                return safeTitle ? `${safeTitle} (${conversation.date}).md` : `${conversation.providerLabel}_Conversation_${conversation.date}.md`;
+            }
+
+            if (format === 'pdf') {
+                return safeTitle ? `${safeTitle} (${conversation.date}) - PrintToPDF.html` : `${conversation.providerLabel}_Conversation_${conversation.date}_PrintToPDF.html`;
+            }
+
+            return safeTitle ? `${safeTitle} (${conversation.date}).html` : `${conversation.providerLabel}_Conversation_${conversation.date}.html`;
+        }
+
+        function mimeFor(format) {
+            return format === 'markdown' ? 'text/markdown' : 'text/html';
+        }
+
+        function downloadFile(doc, content, filename, mimeType) {
+            const win = getWindow(doc);
+            const BlobCtor = win?.Blob || Blob;
+            const urlApi = win?.URL || URL;
+            const blob = new BlobCtor([content], { type: mimeType });
+            const url = urlApi.createObjectURL(blob);
+            const anchor = doc.createElement('a');
+
+            anchor.href = url;
+            anchor.download = filename;
+            doc.body.appendChild(anchor);
+            anchor.click();
+            doc.body.removeChild(anchor);
+            urlApi.revokeObjectURL(url);
+        }
+
+        function exportConversation(options = {}) {
+            const doc = resolveDocument(options.document);
+            const format = options.format || 'markdown';
+            const conversation = extractConversation({
+                ...options,
+                document: doc,
+                format
+            });
+
+            if (conversation.messages.length === 0) {
+                const message = 'No messages found. The page structure may have changed.';
+                const win = getWindow(doc);
+                if (typeof win?.alert === 'function') win.alert(message);
+                console.warn(`[Chat Exporter] ${message}`);
+                return { conversation, content: '' };
+            }
+
+            const content = render(conversation, format);
+            const filename = options.filename || filenameFor(conversation, format, doc);
+
+            if (options.download !== false) {
+                downloadFile(doc, content, filename, mimeFor(format));
+                console.log(`[Chat Exporter] Exported ${conversation.messages.length} messages to ${filename}`);
+            }
+
+            return { conversation, content, filename };
+        }
+
+        return {
+            version: ENGINE_VERSION,
+            providers: PROVIDERS,
+            detectProvider,
+            extractConversation,
+            exportConversation,
+            serializers: {
+                markdown: renderMarkdown,
+                html: conversation => renderHtmlDocument(conversation, { format: 'html' }),
+                pdf: conversation => renderHtmlDocument(conversation, { format: 'pdf' })
+            },
+            internals: {
+                serializeMessageContent,
+                extractCodeBlock,
+                tableToMarkdown,
+                tableToHtml
+            }
+        };
+    });
+
+    globalThis.ChatExporterEngine.exportConversation({
+        provider: 'chatgpt',
+        format: 'html'
+    });
 })();

--- a/exporter-markdown.js
+++ b/exporter-markdown.js
@@ -1,428 +1,1053 @@
+// Generated from src/extraction-engine.js by scripts/build-exporters.js.
+// Edit the source engine or this build script, then run npm run build.
+
 (() => {
-    function formatDate(date = new Date()) {
-        return date.toISOString().split('T')[0];
-    }
+    'use strict';
 
-    function cleanMarkdown(text) {
-        return text
-            // Clean up excessive newlines
-            .replace(/\n{3,}/g, '\n\n')
-            // Remove any HTML entities that might have leaked through
-            .replace(/&lt;/g, '<')
-            .replace(/&gt;/g, '>')
-            .replace(/&amp;/g, '&');
-    }
+    (function initChatExporterEngine(root, factory) {
+        const engine = factory();
 
-    function getText(element) {
-        return (element?.innerText ?? element?.textContent ?? '').trim();
-    }
-
-    function removeUiElements(clone) {
-        // Remove UI elements that shouldn't be in the export.
-        // Do NOT use [class*="edit"]: it matches CodeMirror's "cm-editor" wrapper
-        // that holds the actual code in modern ChatGPT, and would erase code blocks.
-        clone.querySelectorAll('button, svg, [class*="regenerate"], [data-testid*="copy"], [aria-label*="Copy"], [aria-label*="copy"]').forEach(el => el.remove());
-    }
-
-    function extractCodeBlock(pre) {
-        const codeEl = pre.querySelector('code');
-        const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9_-]+)/);
-        let lang = langMatch ? langMatch[1] : '';
-
-        if (!lang) {
-            const header = pre.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code-block"]');
-            const headerText = getText(header).replace(/\b(copy|code|download)\b/gi, '').trim();
-            if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
-                lang = headerText.toLowerCase();
-            }
-            header?.remove();
+        if (root) {
+            root.ChatExporterEngine = engine;
         }
 
-        const cmContent = pre.querySelector('.cm-content');
-        if (cmContent) {
-            const cmLines = cmContent.querySelectorAll('.cm-line');
-            if (cmLines.length > 0) {
-                return { lang, code: Array.from(cmLines).map(line => line.textContent).join('\n').trim() };
-            }
+        if (typeof module !== 'undefined' && module.exports) {
+            module.exports = engine;
+        }
+    })(typeof globalThis !== 'undefined' ? globalThis : this, function buildChatExporterEngine() {
+        'use strict';
 
-            cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
-            return { lang, code: cmContent.textContent.trim() };
+        const ENGINE_VERSION = '0.7.0-live-engine';
+        const MARKER_PREFIX = '__CHAT_EXPORTER_BLOCK_';
+
+        const PROVIDERS = {
+            chatgpt: {
+                id: 'chatgpt',
+                assistantName: 'ChatGPT',
+                sourceLabel: 'chatgpt.com',
+                defaultTitle: 'Conversation with ChatGPT',
+                genericTitlePattern: /^(chatgpt|new chat|untitled|chat)$/i,
+                messageSelectors: [
+                    'div[data-message-author-role]',
+                    'article[data-testid*="conversation-turn"]',
+                    'div[data-testid="conversation-turn"]',
+                    '.group\\/conversation-turn',
+                    '[data-testid*="message"], [data-message-id], [data-message-author]'
+                ],
+                contentSelectors: [
+                    '.markdown, .prose, [class*="markdown"], [class*="prose"]',
+                    '[data-message-content], [data-testid*="content"]',
+                    '.whitespace-pre-wrap, [class*="whitespace"]'
+                ],
+                titleSelectors: [
+                    'h1:not([class*="hidden"])',
+                    '[class*="conversation-title"]',
+                    '[data-testid*="conversation-title"]'
+                ]
+            },
+            gemini: {
+                id: 'gemini',
+                assistantName: 'Gemini',
+                sourceLabel: 'gemini.google.com',
+                defaultTitle: 'Conversation with Gemini',
+                genericTitlePattern: /^(gemini|new chat|untitled|chat|bard)$/i,
+                messageSelectors: [
+                    'user-query, model-response',
+                    '[data-test-id="conversation-turn"]',
+                    '[data-testid="conversation-turn"]',
+                    '[data-message-author-role]',
+                    '[class*="conversation-turn"]',
+                    '[role="listitem"]'
+                ],
+                contentSelectors: [
+                    'message-content',
+                    '.query-text',
+                    '.response-container',
+                    '.markdown, .prose, [class*="markdown"], [class*="prose"]'
+                ],
+                titleSelectors: [
+                    'h1:not([class*="hidden"])',
+                    '[class*="conversation-title"]',
+                    '[data-testid*="conversation-title"]',
+                    '[aria-label*="conversation"]'
+                ]
+            }
+        };
+
+        function resolveDocument(doc) {
+            if (doc) return doc;
+            if (typeof document !== 'undefined') return document;
+            throw new Error('ChatExporterEngine requires a document.');
         }
 
-        return { lang, code: getText(codeEl || pre) };
-    }
+        function getWindow(doc) {
+            return doc.defaultView || (typeof window !== 'undefined' ? window : null);
+        }
 
-    function processCodeBlocks(clone) {
-        clone.querySelectorAll('pre').forEach(pre => {
-            const { lang, code } = extractCodeBlock(pre);
-            const codeBlock = document.createTextNode(`\n\n\`\`\`${lang}\n${code}\n\`\`\`\n`);
-            pre.parentNode.replaceChild(codeBlock, pre);
-        });
-    }
+        function formatDate(date = new Date()) {
+            return date.toISOString().split('T')[0];
+        }
 
-    function processMath(clone) {
-        const processed = new Set();
+        function sanitizeHtml(value) {
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
 
-        clone.querySelectorAll('annotation[encoding*="tex"]').forEach(annotation => {
-            const tex = annotation.textContent.trim();
-            if (!tex) return;
+        function normalizeWhitespace(value) {
+            return String(value ?? '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+        }
 
-            const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
-            const mathRoot = displayRoot || annotation.closest('.katex, mjx-container, math');
-            if (!mathRoot || processed.has(mathRoot)) return;
+        function getClassName(element) {
+            const className = element?.className;
+            if (!className) return '';
+            if (typeof className === 'string') return className;
+            return className.baseVal || '';
+        }
 
-            processed.add(mathRoot);
-            const wrapper = displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`;
-            mathRoot.replaceWith(document.createTextNode(wrapper));
-        });
+        function queryAll(root, selector) {
+            if (!root || !selector) return [];
 
-        clone.querySelectorAll('script[type^="math/tex"]').forEach(script => {
-            const tex = script.textContent.trim();
-            if (!tex) return;
-            const isDisplay = /mode=display/.test(script.type);
-            script.replaceWith(document.createTextNode(isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
-        });
-    }
+            try {
+                return Array.from(root.querySelectorAll(selector));
+            } catch (error) {
+                console.warn('[Chat Exporter] Selector failed:', selector, error);
+                return [];
+            }
+        }
 
-    function processMedia(clone) {
-        clone.querySelectorAll('img, canvas, video, audio').forEach(el => {
-            const tag = el.tagName.toLowerCase();
-            const alt = el.getAttribute('alt') || el.getAttribute('aria-label') || '';
-            const label = tag === 'img' && alt ? `[Image: ${alt}]` :
-                tag === 'canvas' ? '[Canvas or chart]' :
-                tag === 'video' ? '[Video]' :
-                tag === 'audio' ? '[Audio]' :
-                '[Media]';
-            const placeholder = document.createTextNode(label);
-            el.parentNode.replaceChild(placeholder, el);
-        });
-    }
+        function matches(element, selector) {
+            if (!element || !selector || typeof element.matches !== 'function') return false;
 
-    function processLinks(clone) {
-        clone.querySelectorAll('a[href]').forEach(link => {
-            if (link.closest('pre, code')) return;
+            try {
+                return element.matches(selector);
+            } catch (error) {
+                return false;
+            }
+        }
 
-            const href = (link.href || '').trim();
-            const lowerHref = href.toLowerCase();
-            if (!href || lowerHref.startsWith('javascript:') || lowerHref.startsWith('data:') || lowerHref.startsWith('vbscript:') || href.startsWith('#')) return;
+        function getText(element) {
+            if (!element) return '';
+            const innerText = typeof element.innerText === 'string' ? element.innerText : '';
+            return (innerText || element.textContent || '').replace(/\u00a0/g, ' ').trim();
+        }
 
-            const text = link.textContent.replace(/\s+/g, ' ').trim() || href;
-            const escapedText = text
+        function collectTextWithBreaks(node) {
+            if (!node) return '';
+
+            if (node.nodeType === 3) {
+                return node.nodeValue || '';
+            }
+
+            if (node.nodeType !== 1) {
+                return '';
+            }
+
+            const tag = node.tagName.toLowerCase();
+            if (tag === 'br') return '\n';
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+
+            const before = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+            const after = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+            return before + Array.from(node.childNodes).map(collectTextWithBreaks).join('') + after;
+        }
+
+        function getCodeText(element) {
+            if (!element) return '';
+
+            if (typeof element.innerText === 'string' && element.innerText.trim()) {
+                return element.innerText.replace(/\u00a0/g, ' ').replace(/\n{3,}/g, '\n\n').trimEnd();
+            }
+
+            const clone = element.cloneNode(true);
+            queryAll(clone, 'br').forEach(br => br.replaceWith(clone.ownerDocument.createTextNode('\n')));
+            return collectTextWithBreaks(clone).replace(/\n{3,}/g, '\n\n').trimEnd();
+        }
+
+        function normalizeCodeText(value) {
+            return String(value ?? '')
+                .replace(/\r\n?/g, '\n')
+                .replace(/^\n+/, '')
+                .replace(/\n+$/, '');
+        }
+
+        function createTextNode(reference, text) {
+            return reference.ownerDocument.createTextNode(text);
+        }
+
+        function addReplacement(replacements, html) {
+            const marker = `${MARKER_PREFIX}${replacements.length}__`;
+            replacements.push({ marker, html });
+            return marker;
+        }
+
+        function restoreReplacements(value, replacements) {
+            return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), value);
+        }
+
+        function cleanMarkdown(markdown) {
+            return String(markdown ?? '')
+                .split(/(```[\s\S]*?```)/g)
+                .map(part => part.startsWith('```')
+                    ? part
+                    : part
+                        .replace(/[ \t]+\n/g, '\n')
+                        .replace(/\n[ \t]+/g, '\n')
+                        .replace(/\n{3,}/g, '\n\n')
+                        .replace(/&lt;/g, '<')
+                        .replace(/&gt;/g, '>')
+                        .replace(/&amp;/g, '&'))
+                .join('')
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+        }
+
+        function escapeMarkdownLinkText(value) {
+            return String(value ?? '')
                 .replace(/\\/g, '\\\\')
                 .replace(/([\[\]])/g, '\\$1');
-            const safeHref = href
+        }
+
+        function escapeMarkdownUrl(value) {
+            return String(value ?? '')
                 .replace(/\\/g, '%5C')
                 .replace(/\)/g, '%29');
-            const markdown = `[${escapedText}](${safeHref})`;
-            link.parentNode.replaceChild(document.createTextNode(markdown), link);
-        });
-    }
-
-    function tableCellText(cell) {
-        return getText(cell).replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim() || ' ';
-    }
-
-    function tableToMarkdown(table) {
-        const rows = Array.from(table.querySelectorAll('tr'))
-            .map(row => Array.from(row.children)
-                .filter(cell => ['TH', 'TD'].includes(cell.tagName))
-                .map(tableCellText))
-            .filter(cells => cells.length > 0);
-
-        if (rows.length === 0) return getText(table);
-
-        const width = Math.max(...rows.map(row => row.length));
-        const normalizedRows = rows.map(row => row.concat(Array(Math.max(0, width - row.length)).fill(' ')));
-        const header = normalizedRows[0];
-        const separator = header.map(() => '---');
-        const body = normalizedRows.slice(1);
-        const lines = [
-            `| ${header.join(' | ')} |`,
-            `| ${separator.join(' | ')} |`,
-            ...body.map(row => `| ${row.join(' | ')} |`)
-        ];
-
-        return `\n\n${lines.join('\n')}\n\n`;
-    }
-
-    function processTables(clone) {
-        clone.querySelectorAll('table').forEach(table => {
-            table.replaceWith(document.createTextNode(tableToMarkdown(table)));
-        });
-    }
-
-    function processMessageContent(element) {
-        const clone = element.cloneNode(true);
-
-        removeUiElements(clone);
-        processCodeBlocks(clone);
-        processMath(clone);
-        processMedia(clone);
-        processLinks(clone);
-        processTables(clone);
-
-        // Convert remaining HTML to clean markdown text
-        return cleanMarkdown(getText(clone));
-    }
-
-    function findMessages() {
-        // More specific selectors to avoid nested elements
-        const selectors = [
-            'div[data-message-author-role]', // Modern ChatGPT with clear author role
-            'article[data-testid*="conversation-turn"]', // Conversation turns
-            'div[data-testid="conversation-turn"]', // Specific conversation turn
-            '.group\\/conversation-turn', // Fix for issue #6: More specific selector for conversation turns
-            'div[class*="group"]:not([class*="group"] [class*="group"])', // Top-level groups only
-        ];
-
-        let messages = [];
-        for (const selector of selectors) {
-            messages = document.querySelectorAll(selector);
-            if (messages.length > 0) {
-                console.log(`Using selector: ${selector}, found ${messages.length} messages`);
-                break;
-            }
         }
 
-        if (messages.length === 0) {
-            // Fallback: try to find conversation container and parse its structure
-            const conversationContainer = document.querySelector('[role="main"], main, .conversation, [class*="conversation"]');
-            if (conversationContainer) {
-                // Look for direct children that seem like message containers
-                messages = conversationContainer.querySelectorAll(':scope > div, :scope > article');
-                console.log(`Fallback: found ${messages.length} potential messages in conversation container`);
-            }
+        function isUnsafeHref(href) {
+            const lower = String(href || '').trim().toLowerCase();
+            return !lower ||
+                lower.startsWith('javascript:') ||
+                lower.startsWith('data:') ||
+                lower.startsWith('vbscript:') ||
+                lower.startsWith('#');
         }
 
-        // Filter and validate messages
-        const validMessages = Array.from(messages).filter(msg => {
-            const text = msg.textContent.trim();
-            
-            // Must have substantial content
-            if (text.length < 30) return false;
-            if (text.length > 100000) return false;
-            
-            // Skip elements that are clearly UI components
-            if (msg.querySelector('input[type="text"], textarea')) return false;
-            if (msg.classList.contains('typing') || msg.classList.contains('loading')) return false;
-            
-            // Must contain meaningful content (not just buttons/UI)
-            const meaningfulText = text.replace(/\s+/g, ' ').trim();
-            if (meaningfulText.split(' ').length < 5) return false;
-            
-            return true;
-        });
-
-        // Remove nested messages and consolidate content
-        const consolidatedMessages = [];
-        const usedElements = new Set();
-
-        validMessages.forEach(msg => {
-            if (usedElements.has(msg)) return;
-            
-            // Check if this message is nested within another valid message
-            const isNested = validMessages.some(other => 
-                other !== msg && other.contains(msg) && !usedElements.has(other)
-            );
-            
-            if (!isNested) {
-                consolidatedMessages.push(msg);
-                usedElements.add(msg);
-            }
-        });
-
-        return consolidatedMessages;
-    }
-
-    function identifySender(messageElement, index, allMessages) {
-        // Method 1: Check for data attributes (most reliable)
-        const authorRole = messageElement.getAttribute('data-message-author-role');
-        if (authorRole) {
-            return authorRole === 'user' ? 'You' : 'ChatGPT';
+        function topLevelElements(elements) {
+            return elements.filter(element => !elements.some(other => other !== element && other.contains(element)));
         }
 
-        // Method 2: Look for avatar images with better detection
-        const avatars = messageElement.querySelectorAll('img');
-        for (const avatar of avatars) {
-            const alt = avatar.alt?.toLowerCase() || '';
-            const src = avatar.src?.toLowerCase() || '';
-            const classes = avatar.className?.toLowerCase() || '';
-            
-            // User indicators
-            if (alt.includes('user') || src.includes('user') || classes.includes('user')) {
-                return 'You';
-            }
-            
-            // Assistant indicators
-            if (alt.includes('chatgpt') || alt.includes('assistant') || alt.includes('gpt') || 
-                src.includes('assistant') || src.includes('chatgpt') || classes.includes('assistant')) {
-                return 'ChatGPT';
-            }
+        function removeUiElements(clone) {
+            const uiSelector = [
+                'button',
+                'svg',
+                'style',
+                'script',
+                'textarea',
+                'input',
+                '[contenteditable="true"]',
+                '[class*="regenerate"]',
+                '[class*="copy-button"]',
+                '[data-testid*="copy"]',
+                '[data-test-id*="copy"]',
+                '[aria-label*="Copy"]',
+                '[aria-label*="copy"]',
+                '[aria-label*="More"]',
+                '[aria-label*="more"]'
+            ].join(',');
+
+            queryAll(clone, uiSelector).forEach(element => element.remove());
         }
 
-        // Method 3: Content analysis with better patterns
-        const text = messageElement.textContent.toLowerCase();
-        const textStart = text.substring(0, 200); // Look at beginning of message
-        
-        // Strong ChatGPT indicators
-        if (textStart.match(/^(i understand|i can help|here's|i'll|let me|i'd be happy|certainly|of course)/)) {
-            return 'ChatGPT';
-        }
-        
-        // Strong user indicators  
-        if (textStart.match(/^(can you|please help|how do i|i need|i want|help me|could you)/)) {
-            return 'You';
-        }
+        function detectLanguage(block) {
+            const codeElement = matches(block, 'code') ? block : block.querySelector('code');
+            const sources = [
+                codeElement?.className,
+                block.getAttribute?.('data-language'),
+                block.getAttribute?.('language'),
+                block.getAttribute?.('lang'),
+                codeElement?.getAttribute?.('data-language'),
+                codeElement?.getAttribute?.('language'),
+                codeElement?.getAttribute?.('lang'),
+                block.getAttribute?.('aria-label')
+            ].filter(Boolean).map(String);
 
-        // Method 4: Structural analysis - look at DOM structure
-        const hasCodeBlocks = messageElement.querySelectorAll('pre, code').length > 0;
-        const hasLongText = messageElement.textContent.length > 200;
-        const hasLists = messageElement.querySelectorAll('ul, ol, li').length > 0;
-        
-        // ChatGPT messages tend to be longer and more structured
-        if (hasCodeBlocks && hasLongText && hasLists) {
-            return 'ChatGPT';
-        }
-
-        // Method 5: Position-based fallback with better logic
-        // Try to detect actual alternating pattern by looking at content characteristics
-        if (index > 0 && allMessages[index - 1]) {
-            const prevText = allMessages[index - 1].textContent;
-            const currentText = messageElement.textContent;
-            
-            // If previous was short and current is long, likely user -> assistant
-            if (prevText.length < 100 && currentText.length > 300) {
-                return 'ChatGPT';
-            }
-            
-            // If previous was long and current is short, likely assistant -> user  
-            if (prevText.length > 300 && currentText.length < 100) {
-                return 'You';
-            }
-        }
-
-        // Final fallback
-        return index % 2 === 0 ? 'You' : 'ChatGPT';
-    }
-
-    function extractConversationTitle() {
-        // Try to get actual conversation title
-        const titleSelectors = [
-            'h1:not([class*="hidden"])',
-            '[class*="conversation-title"]',
-            '[data-testid*="conversation-title"]',
-            'title'
-        ];
-
-        for (const selector of titleSelectors) {
-            const element = document.querySelector(selector);
-            if (element && element.textContent.trim()) {
-                const title = element.textContent.trim();
-                // Avoid generic titles
-                if (!['chatgpt', 'new chat', 'untitled', 'chat'].includes(title.toLowerCase())) {
-                    return title;
+            for (const source of sources) {
+                const languageMatch = source.match(/language-([a-zA-Z0-9_+#.-]+)/);
+                if (languageMatch) return languageMatch[1].toLowerCase();
+                if (/^[a-zA-Z0-9_+#.-]{1,24}$/.test(source) && !/^(code|copy|download)$/i.test(source)) {
+                    return source.toLowerCase();
                 }
             }
-        }
 
-        return 'Conversation with ChatGPT';
-    }
-
-    // Main export logic
-    const messages = findMessages();
-    
-    if (messages.length === 0) {
-        alert('No messages found. The page structure may have changed.');
-        return;
-    }
-
-    console.log(`Processing ${messages.length} messages...`);
-
-    const lines = [];
-    const title = extractConversationTitle();
-    const date = formatDate();
-    const url = window.location.href;
-
-    lines.push(`# ${title}\n`);
-    lines.push(`**Date:** ${date}`);
-    lines.push(`**Source:** [chat.openai.com](${url})\n`);
-    lines.push(`---\n`);
-
-    // Process messages with better duplicate detection
-    const processedMessages = [];
-    const seenContent = new Set();
-
-    messages.forEach((messageElement, index) => {
-        const sender = identifySender(messageElement, index, messages);
-        const content = processMessageContent(messageElement);
-        
-        // Skip if empty or too short
-        if (!content || content.trim().length < 30) {
-            console.log(`Skipping message ${index}: too short or empty`);
-            return;
-        }
-
-        // Create a content hash for duplicate detection
-        const contentHash = content.substring(0, 100).replace(/\s+/g, ' ').trim();
-        if (seenContent.has(contentHash)) {
-            console.log(`Skipping message ${index}: duplicate content`);
-            return;
-        }
-        seenContent.add(contentHash);
-
-        processedMessages.push({
-            sender,
-            content,
-            originalIndex: index
-        });
-    });
-
-    // Apply sender sequence correction
-    for (let i = 1; i < processedMessages.length; i++) {
-        const current = processedMessages[i];
-        const previous = processedMessages[i - 1];
-        
-        // If we have two consecutive messages from the same sender, try to fix it
-        if (current.sender === previous.sender) {
-            // Use content analysis to determine which should be flipped
-            const currentLength = current.content.length;
-            const previousLength = previous.content.length;
-            
-            // If current message is much longer, it's likely ChatGPT
-            if (currentLength > previousLength * 2 && currentLength > 500) {
-                current.sender = 'ChatGPT';
-            } else if (previousLength > currentLength * 2 && previousLength > 500) {
-                previous.sender = 'ChatGPT';
-                current.sender = 'You';
-            } else {
-                // Default alternating fix
-                current.sender = current.sender === 'You' ? 'ChatGPT' : 'You';
+            const header = block.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code"], [data-test-id*="code"], .code-language, .code-lang, [slot="header"]');
+            const headerText = normalizeWhitespace(getText(header)).replace(/\b(copy|code|download)\b/gi, '').trim();
+            if (headerText && headerText.length < 32 && !headerText.includes('\n')) {
+                return headerText.toLowerCase();
             }
-            
-            console.log(`Fixed consecutive ${previous.sender} messages at positions ${i-1} and ${i}`);
-        }
-    }
 
-    // Generate final output
-    processedMessages.forEach(({ sender, content }) => {
-        lines.push(`### **${sender}**\n`);
-        lines.push(content);
-        lines.push('\n---\n');
+            return '';
+        }
+
+        function extractCodeBlock(block) {
+            const clone = block.cloneNode(true);
+            const language = detectLanguage(clone);
+
+            queryAll(clone, 'button, svg, [aria-label*="Copy"], [aria-label*="copy"], [class*="sticky"], [class*="code-header"], [data-testid*="copy"], [data-test-id*="copy"], [slot="header"]').forEach(element => element.remove());
+
+            const cmContent = clone.querySelector('.cm-content');
+            if (cmContent) {
+                const cmLines = queryAll(cmContent, '.cm-line');
+                if (cmLines.length > 0) {
+                    return {
+                        lang: language,
+                        code: normalizeCodeText(cmLines.map(line => line.textContent || '').join('\n'))
+                    };
+                }
+
+                return {
+                    lang: language,
+                    code: normalizeCodeText(getCodeText(cmContent))
+                };
+            }
+
+            const codeElement = matches(clone, 'code') ? clone : clone.querySelector('code');
+            return {
+                lang: language,
+                code: normalizeCodeText(getCodeText(codeElement || clone))
+            };
+        }
+
+        function formatCodeBlock(block, format, replacements) {
+            const { lang, code } = extractCodeBlock(block);
+
+            if (format === 'markdown') {
+                return `\n\n\`\`\`${lang}\n${code}\n\`\`\`\n\n`;
+            }
+
+            const langClass = lang ? ` class="language-${sanitizeHtml(lang)}"` : '';
+            if (format === 'pdf') {
+                const label = lang ? `<div class="code-language">${sanitizeHtml(lang)}</div>` : '';
+                return addReplacement(replacements, `<pre class="code-block">${label}<code>${sanitizeHtml(code)}</code></pre>`);
+            }
+
+            return addReplacement(replacements, `<pre><code${langClass}>${sanitizeHtml(code)}</code></pre>`);
+        }
+
+        function processCodeBlocks(clone, format, replacements) {
+            const blocks = topLevelElements(queryAll(clone, 'pre, code-block, [data-testid*="code-block"], [data-test-id*="code-block"]'));
+
+            blocks.forEach(block => {
+                const replacement = formatCodeBlock(block, format, replacements);
+                block.replaceWith(createTextNode(block, replacement));
+            });
+        }
+
+        function processMath(clone) {
+            const processed = new Set();
+
+            queryAll(clone, 'annotation').forEach(annotation => {
+                const encoding = (annotation.getAttribute('encoding') || '').toLowerCase();
+                if (!encoding.includes('tex') && !encoding.includes('latex')) return;
+
+                const tex = annotation.textContent.trim();
+                if (!tex) return;
+
+                const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
+                const mathRoot = displayRoot || annotation.closest('.katex') || annotation.closest('mjx-container') || annotation.closest('math');
+                if (!mathRoot || processed.has(mathRoot)) return;
+
+                processed.add(mathRoot);
+                mathRoot.replaceWith(createTextNode(mathRoot, displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+            });
+
+            queryAll(clone, 'script[type^="math/tex"]').forEach(script => {
+                const tex = script.textContent.trim();
+                if (!tex) return;
+                const isDisplay = /mode=display/.test(script.type);
+                script.replaceWith(createTextNode(script, isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+            });
+        }
+
+        function processMedia(clone, format, replacements) {
+            queryAll(clone, 'img, canvas, video, audio').forEach(element => {
+                const tag = element.tagName.toLowerCase();
+                const alt = normalizeWhitespace(element.getAttribute('alt') || element.getAttribute('aria-label') || element.getAttribute('title') || '');
+                const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                    tag === 'img' ? '[Image]' :
+                    tag === 'canvas' ? '[Canvas or chart]' :
+                    tag === 'video' ? '[Video]' :
+                    tag === 'audio' ? '[Audio]' :
+                    '[Media]';
+
+                const replacement = format === 'markdown'
+                    ? label
+                    : addReplacement(replacements, `<span class="media-placeholder">${sanitizeHtml(label)}</span>`);
+                element.replaceWith(createTextNode(element, replacement));
+            });
+        }
+
+        function processLinks(clone, format, replacements) {
+            queryAll(clone, 'a[href]').forEach(link => {
+                if (link.closest('pre, code, code-block')) return;
+
+                const href = String(link.href || link.getAttribute('href') || '').trim();
+                if (isUnsafeHref(href)) return;
+
+                const text = normalizeWhitespace(link.textContent) || href;
+                const replacement = format === 'markdown'
+                    ? `[${escapeMarkdownLinkText(text)}](${escapeMarkdownUrl(href)})`
+                    : addReplacement(replacements, `<a href="${sanitizeHtml(href)}">${sanitizeHtml(text)}</a>`);
+
+                link.replaceWith(createTextNode(link, replacement));
+            });
+        }
+
+        function tableCellText(cell) {
+            return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+        }
+
+        function tableToMarkdown(table) {
+            const rows = queryAll(table, 'tr')
+                .map(row => Array.from(row.children)
+                    .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                    .map(tableCellText))
+                .filter(row => row.length > 0);
+
+            if (rows.length === 0) return normalizeWhitespace(getText(table));
+
+            const width = Math.max(...rows.map(row => row.length));
+            const normalizedRows = rows.map(row => row.concat(Array(Math.max(0, width - row.length)).fill(' ')));
+            const header = normalizedRows[0];
+            const separator = header.map(() => '---');
+            const body = normalizedRows.slice(1);
+
+            return [
+                `| ${header.join(' | ')} |`,
+                `| ${separator.join(' | ')} |`,
+                ...body.map(row => `| ${row.join(' | ')} |`)
+            ].join('\n');
+        }
+
+        function tableToHtml(table) {
+            const rows = queryAll(table, 'tr')
+                .map(row => Array.from(row.children)
+                    .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                    .map(cell => ({
+                        tag: cell.tagName.toLowerCase(),
+                        text: normalizeWhitespace(getText(cell))
+                    })))
+                .filter(row => row.length > 0);
+
+            if (rows.length === 0) return sanitizeHtml(getText(table));
+
+            return `<table>${rows.map(row => {
+                const cells = row.map(cell => `<${cell.tag}>${sanitizeHtml(cell.text)}</${cell.tag}>`).join('');
+                return `<tr>${cells}</tr>`;
+            }).join('')}</table>`;
+        }
+
+        function processTables(clone, format, replacements) {
+            topLevelElements(queryAll(clone, 'table')).forEach(table => {
+                const replacement = format === 'markdown'
+                    ? `\n\n${tableToMarkdown(table)}\n\n`
+                    : addReplacement(replacements, tableToHtml(table));
+                table.replaceWith(createTextNode(table, replacement));
+            });
+        }
+
+        function cardSignal(element) {
+            const pieces = [
+                element.tagName,
+                getClassName(element),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id'),
+                element.getAttribute('aria-label'),
+                element.getAttribute('role')
+            ].filter(Boolean).join(' ').toLowerCase();
+
+            if (/\b(artifact|canvas-preview|generated-file|download-card|attachment|file-card)\b/.test(pieces)) {
+                return pieces.includes('artifact') || pieces.includes('canvas-preview') ? 'Artifact' : 'File';
+            }
+
+            if (/(^|[\s_-])(attachment|file)([\s_-]|$)/.test(pieces)) {
+                return 'File';
+            }
+
+            return '';
+        }
+
+        function cardLabel(element) {
+            const candidates = [
+                element.getAttribute('aria-label'),
+                element.getAttribute('title'),
+                element.getAttribute('download'),
+                element.getAttribute('data-filename'),
+                getText(element)
+            ].filter(Boolean).map(normalizeWhitespace);
+
+            const label = candidates.find(value => value && value.length <= 180) || '';
+            return label
+                .replace(/\b(open|download|preview|file|attachment|artifact)\b/gi, ' ')
+                .replace(/\s+/g, ' ')
+                .trim();
+        }
+
+        function processCards(clone, format, replacements) {
+            const cards = topLevelElements(Array.from(clone.querySelectorAll('*')).filter(element => {
+                const kind = cardSignal(element);
+                if (!kind) return false;
+                if (matches(element, '[data-message-author-role], user-query, model-response')) return false;
+                if (element.closest('pre, code, code-block, table')) return false;
+                if (element.querySelector('pre, code-block, table, user-query, model-response')) return false;
+
+                const text = normalizeWhitespace(getText(element));
+                const label = cardLabel(element);
+                return Boolean(label || text) && text.length <= 240;
+            }));
+
+            cards.forEach(card => {
+                const kind = cardSignal(card);
+                const label = cardLabel(card);
+                const text = label ? `[${kind}: ${label}]` : `[${kind}]`;
+                const replacement = format === 'markdown'
+                    ? text
+                    : addReplacement(replacements, `<span class="card-placeholder">${sanitizeHtml(text)}</span>`);
+                card.replaceWith(createTextNode(card, replacement));
+            });
+        }
+
+        function serializeMarkdownChildren(element, context = {}) {
+            return Array.from(element.childNodes).map((node, index) => serializeMarkdownNode(node, {
+                ...context,
+                index
+            })).join('');
+        }
+
+        function serializeMarkdownNode(node, context = {}) {
+            if (node.nodeType === 3) {
+                const value = node.nodeValue || '';
+                if (value.includes('```') || value.includes('| ---') || value.includes(MARKER_PREFIX) || value.match(/^\s*\[[^\]]+\]/)) {
+                    return value;
+                }
+                return value.replace(/[ \t\r\n]+/g, ' ');
+            }
+
+            if (node.nodeType !== 1) return '';
+
+            const tag = node.tagName.toLowerCase();
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+            if (tag === 'br') return '\n';
+
+            if (/^h[1-6]$/.test(tag)) {
+                const level = Number(tag.slice(1));
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${'#'.repeat(level)} ${content}\n\n` : '';
+            }
+
+            if (tag === 'p') {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${content}\n\n` : '';
+            }
+
+            if (tag === 'blockquote') {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${content.split('\n').map(line => `> ${line.trim()}`).join('\n')}\n\n` : '';
+            }
+
+            if (tag === 'ul' || tag === 'ol') {
+                const children = Array.from(node.children).filter(child => child.tagName && child.tagName.toLowerCase() === 'li');
+                return `\n${children.map((child, index) => serializeMarkdownNode(child, {
+                    ...context,
+                    listType: tag,
+                    index,
+                    depth: (context.depth || 0)
+                })).join('')}\n`;
+            }
+
+            if (tag === 'li') {
+                const depth = context.depth || 0;
+                const marker = context.listType === 'ol' ? `${(context.index || 0) + 1}. ` : '- ';
+                const indent = '  '.repeat(depth);
+                const content = serializeMarkdownChildren(node, {
+                    ...context,
+                    depth: depth + 1
+                }).trim();
+                return content ? `${indent}${marker}${content.replace(/\n+/g, `\n${indent}  `)}\n` : '';
+            }
+
+            if (['strong', 'b'].includes(tag)) {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `**${content}**` : '';
+            }
+
+            if (['em', 'i'].includes(tag)) {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `*${content}*` : '';
+            }
+
+            if (tag === 'code') {
+                const content = getCodeText(node).replace(/`/g, '\\`').trim();
+                return content ? `\`${content}\`` : '';
+            }
+
+            const content = serializeMarkdownChildren(node, context);
+            if (['div', 'section', 'article', 'main', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+                return content;
+            }
+
+            return content;
+        }
+
+        function serializeHtmlChildren(element, replacements) {
+            return Array.from(element.childNodes).map(node => serializeHtmlNode(node, replacements)).join('');
+        }
+
+        function serializeHtmlNode(node, replacements) {
+            if (node.nodeType === 3) {
+                return sanitizeHtml(node.nodeValue || '');
+            }
+
+            if (node.nodeType !== 1) return '';
+
+            const tag = node.tagName.toLowerCase();
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+            if (tag === 'br') return '<br>';
+
+            const content = serializeHtmlChildren(node, replacements);
+            const blockTags = new Set(['p', 'ul', 'ol', 'li', 'blockquote', 'strong', 'b', 'em', 'i']);
+
+            if (/^h[1-6]$/.test(tag)) {
+                return `<${tag}>${content}</${tag}>`;
+            }
+
+            if (blockTags.has(tag)) {
+                const safeTag = tag === 'b' ? 'strong' : tag === 'i' ? 'em' : tag;
+                return `<${safeTag}>${content}</${safeTag}>`;
+            }
+
+            if (tag === 'code') {
+                return `<code>${sanitizeHtml(getCodeText(node).trim())}</code>`;
+            }
+
+            if (['div', 'section', 'article', 'main', 'span', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+                return content;
+            }
+
+            return content;
+        }
+
+        function serializeMessageContent(element, format) {
+            const clone = element.cloneNode(true);
+            const replacements = [];
+
+            removeUiElements(clone);
+            processCards(clone, format, replacements);
+            processCodeBlocks(clone, format, replacements);
+            processMath(clone);
+            processMedia(clone, format, replacements);
+            processLinks(clone, format, replacements);
+            processTables(clone, format, replacements);
+
+            if (format === 'markdown') {
+                return cleanMarkdown(serializeMarkdownChildren(clone));
+            }
+
+            const html = serializeHtmlChildren(clone, replacements)
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+            return restoreReplacements(html, replacements);
+        }
+
+        function detectProvider(doc) {
+            const url = doc.defaultView?.location?.href || '';
+            if (/gemini\.google\.com/i.test(url) || doc.querySelector('user-query, model-response')) return 'gemini';
+            return 'chatgpt';
+        }
+
+        function providerFor(providerName, doc) {
+            const id = providerName || detectProvider(doc);
+            return PROVIDERS[id] || PROVIDERS.chatgpt;
+        }
+
+        function meaningfulScore(element) {
+            const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+            return normalizeWhitespace(element.textContent).length + richCount * 200;
+        }
+
+        function isValidMessage(element) {
+            const text = normalizeWhitespace(element.textContent);
+            const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+
+            if (text.length < 5 && richCount === 0) return false;
+            if (text.length > 200000) return false;
+            if (matches(element, 'nav, aside, header, footer, form, menu')) return false;
+            if (element.querySelector('textarea, input[type="text"], [contenteditable="true"]') && !element.hasAttribute('data-message-author-role')) return false;
+            if (getClassName(element).match(/\b(typing|loading|spinner)\b/i)) return false;
+
+            return true;
+        }
+
+        function findMessages(doc, provider) {
+            for (const selector of provider.messageSelectors) {
+                const messages = topLevelElements(queryAll(doc, selector)).filter(isValidMessage);
+                if (messages.length > 0) {
+                    console.log(`[Chat Exporter] ${provider.id}: using selector "${selector}" (${messages.length} messages)`);
+                    return messages;
+                }
+            }
+
+            const container = doc.querySelector('[role="main"], main, [class*="conversation"], [class*="chat"]');
+            if (!container) return [];
+
+            return topLevelElements(queryAll(container, ':scope > article, :scope > section, :scope > div')).filter(isValidMessage);
+        }
+
+        function selectContentRoot(messageElement, provider) {
+            const candidates = [messageElement];
+
+            provider.contentSelectors.forEach(selector => {
+                if (matches(messageElement, selector)) candidates.push(messageElement);
+                candidates.push(...queryAll(messageElement, selector));
+            });
+
+            return candidates
+                .filter(Boolean)
+                .sort((a, b) => meaningfulScore(b) - meaningfulScore(a))[0] || messageElement;
+        }
+
+        function identifySender(element, index, provider) {
+            const tag = element.tagName.toLowerCase();
+            if (tag === 'user-query') return { sender: 'You', reliable: true };
+            if (tag === 'model-response') return { sender: provider.assistantName, reliable: true };
+
+            const role = element.getAttribute('data-message-author-role') || element.getAttribute('data-author') || element.getAttribute('data-sender');
+            if (role) {
+                const normalizedRole = role.toLowerCase();
+                if (normalizedRole === 'user') return { sender: 'You', reliable: true };
+                if (['assistant', 'model', 'bot', 'chatgpt', 'gemini'].includes(normalizedRole)) {
+                    return { sender: provider.assistantName, reliable: true };
+                }
+            }
+
+            const classAndAttrs = [
+                getClassName(element),
+                element.getAttribute('aria-label'),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id')
+            ].filter(Boolean).join(' ').toLowerCase();
+
+            if (classAndAttrs.match(/\b(user|human|query)\b/)) return { sender: 'You', reliable: false };
+            if (classAndAttrs.match(/\b(assistant|model|response|chatgpt|gemini|bard)\b/)) return { sender: provider.assistantName, reliable: false };
+
+            const textStart = normalizeWhitespace(element.textContent).slice(0, 220).toLowerCase();
+            if (/^(i understand|i can help|here's|i'll|let me|i'd be happy|certainly|of course|absolutely)/.test(textStart)) {
+                return { sender: provider.assistantName, reliable: false };
+            }
+
+            if (/^(can you|please help|how do i|i need|i want|help me|could you|explain|what is)/.test(textStart)) {
+                return { sender: 'You', reliable: false };
+            }
+
+            return { sender: index % 2 === 0 ? 'You' : provider.assistantName, reliable: false };
+        }
+
+        function contentHash(content) {
+            return normalizeWhitespace(String(content || '').replace(/<[^>]+>/g, ' ')).slice(0, 160);
+        }
+
+        function extractConversation(options = {}) {
+            const doc = resolveDocument(options.document);
+            const provider = providerFor(options.provider, doc);
+            const format = options.format || 'markdown';
+            const rawMessages = findMessages(doc, provider);
+            const seen = new Set();
+            const messages = [];
+
+            rawMessages.forEach((messageElement, index) => {
+                const contentRoot = selectContentRoot(messageElement, provider);
+                const content = serializeMessageContent(contentRoot, format);
+                const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
+
+                if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+
+                const hash = contentHash(content);
+                if (seen.has(hash)) return;
+                seen.add(hash);
+
+                const sender = identifySender(messageElement, index, provider);
+                messages.push({
+                    sender: sender.sender,
+                    senderType: sender.sender === 'You' ? 'user' : 'assistant',
+                    reliableSender: sender.reliable,
+                    content,
+                    index
+                });
+            });
+
+            return {
+                version: ENGINE_VERSION,
+                provider: provider.id,
+                providerLabel: provider.assistantName,
+                sourceLabel: provider.sourceLabel,
+                title: extractConversationTitle(doc, provider),
+                sourceUrl: doc.defaultView?.location?.href || '',
+                date: formatDate(options.date || new Date()),
+                messages
+            };
+        }
+
+        function extractConversationTitle(doc, provider) {
+            for (const selector of provider.titleSelectors) {
+                const element = doc.querySelector(selector);
+                const title = normalizeWhitespace(element?.textContent);
+                if (title && !provider.genericTitlePattern.test(title)) return title;
+            }
+
+            const docTitle = normalizeWhitespace(doc.title);
+            if (docTitle && !provider.genericTitlePattern.test(docTitle)) return docTitle;
+
+            return provider.defaultTitle;
+        }
+
+        function renderMarkdown(conversation) {
+            const lines = [
+                `# ${conversation.title}\n`,
+                `**Date:** ${conversation.date}`,
+                `**Source:** [${conversation.sourceLabel}](${conversation.sourceUrl})\n`,
+                '---\n'
+            ];
+
+            conversation.messages.forEach(message => {
+                lines.push(`### **${message.sender}**\n`, message.content, '\n---\n');
+            });
+
+            return `${lines.join('\n').trim()}\n`;
+        }
+
+        function renderHtmlDocument(conversation, options = {}) {
+            const isPdf = options.format === 'pdf';
+            const source = sanitizeHtml(conversation.sourceUrl);
+            const title = sanitizeHtml(conversation.title);
+            const messages = conversation.messages.map(message => {
+                const senderClass = message.senderType === 'user' ? 'user' : 'assistant';
+                return `
+            <div class="message ${senderClass}">
+                <div class="sender">${sanitizeHtml(message.sender)}</div>
+                <div class="content">${message.content}</div>
+            </div>`;
+            }).join('');
+
+            const pdfInstructions = isPdf ? `
+        <div class="instructions no-print">
+            <h3>Convert to PDF</h3>
+            <ol>
+                <li>Press Ctrl+P on Windows/Linux or Cmd+P on Mac.</li>
+                <li>Set Destination to Save as PDF.</li>
+                <li>Choose your preferred page size.</li>
+                <li>Click Save.</li>
+            </ol>
+            <p><em>This instruction box will not appear in the PDF.</em></p>
+        </div>` : '';
+
+            return `<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <title>${title} - ${conversation.date}</title>
+        <style>
+            @media print {
+                body { margin: 0; }
+                .no-print { display: none; }
+                .message { page-break-inside: avoid; }
+            }
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+                max-width: 840px;
+                margin: auto;
+                padding: 2rem;
+                background: #fff;
+                color: #333;
+                line-height: 1.6;
+            }
+            .header {
+                text-align: center;
+                margin-bottom: 2rem;
+                padding-bottom: 1rem;
+                border-bottom: 2px solid #eee;
+            }
+            .metadata {
+                color: #666;
+                font-size: 0.9rem;
+            }
+            .message {
+                margin-bottom: 1.5rem;
+                padding: 1rem;
+                border-radius: 8px;
+                background: #f8f9fa;
+            }
+            .message.user {
+                background: #eaf4ff;
+            }
+            .sender {
+                font-weight: 700;
+                color: #2c3e50;
+                margin-bottom: 0.5rem;
+            }
+            .content {
+                white-space: pre-wrap;
+                overflow-wrap: anywhere;
+            }
+            pre {
+                background: #f4f4f4;
+                padding: 1rem;
+                border-radius: 4px;
+                overflow-x: auto;
+                border-left: 4px solid #007acc;
+            }
+            .code-block {
+                background: #282c34;
+                color: #abb2bf;
+                border-left: 0;
+            }
+            .code-block code {
+                white-space: pre;
+            }
+            .code-language {
+                color: #d7dae0;
+                font-size: 12px;
+                margin-bottom: 8px;
+                text-transform: uppercase;
+            }
+            code {
+                font-family: Consolas, Monaco, "Courier New", monospace;
+                font-size: 0.92rem;
+            }
+            table {
+                width: 100%;
+                border-collapse: collapse;
+                margin: 1rem 0;
+            }
+            th, td {
+                border: 1px solid #d9dde3;
+                padding: 0.5rem;
+                text-align: left;
+                vertical-align: top;
+            }
+            th {
+                background: #eef2f7;
+            }
+            .instructions {
+                background: #fff8dc;
+                border: 1px solid #e3c565;
+                border-radius: 8px;
+                padding: 1rem;
+                margin-bottom: 1.5rem;
+            }
+        </style>
+    </head>
+    <body>
+        ${pdfInstructions}
+        <div class="header">
+            <h1>${title}</h1>
+            <div class="metadata">
+                <div><strong>Date:</strong> ${sanitizeHtml(conversation.date)}</div>
+                <div><strong>Source:</strong> <a href="${source}">${sanitizeHtml(conversation.sourceLabel)}</a></div>
+                <div><strong>Messages:</strong> ${conversation.messages.length}</div>
+            </div>
+        </div>
+        <div class="conversation">${messages}
+        </div>
+    </body>
+    </html>`;
+        }
+
+        function render(conversation, format) {
+            if (format === 'markdown') return renderMarkdown(conversation);
+            if (format === 'pdf') return renderHtmlDocument(conversation, { format: 'pdf' });
+            if (format === 'html') return renderHtmlDocument(conversation, { format: 'html' });
+            throw new Error(`Unsupported export format: ${format}`);
+        }
+
+        function filenameFor(conversation, format, doc) {
+            const safeTitle = normalizeWhitespace(doc.title || conversation.title)
+                .replace(/[<>:"/\\|?*]/g, '')
+                .slice(0, 120);
+
+            if (format === 'markdown') {
+                return safeTitle ? `${safeTitle} (${conversation.date}).md` : `${conversation.providerLabel}_Conversation_${conversation.date}.md`;
+            }
+
+            if (format === 'pdf') {
+                return safeTitle ? `${safeTitle} (${conversation.date}) - PrintToPDF.html` : `${conversation.providerLabel}_Conversation_${conversation.date}_PrintToPDF.html`;
+            }
+
+            return safeTitle ? `${safeTitle} (${conversation.date}).html` : `${conversation.providerLabel}_Conversation_${conversation.date}.html`;
+        }
+
+        function mimeFor(format) {
+            return format === 'markdown' ? 'text/markdown' : 'text/html';
+        }
+
+        function downloadFile(doc, content, filename, mimeType) {
+            const win = getWindow(doc);
+            const BlobCtor = win?.Blob || Blob;
+            const urlApi = win?.URL || URL;
+            const blob = new BlobCtor([content], { type: mimeType });
+            const url = urlApi.createObjectURL(blob);
+            const anchor = doc.createElement('a');
+
+            anchor.href = url;
+            anchor.download = filename;
+            doc.body.appendChild(anchor);
+            anchor.click();
+            doc.body.removeChild(anchor);
+            urlApi.revokeObjectURL(url);
+        }
+
+        function exportConversation(options = {}) {
+            const doc = resolveDocument(options.document);
+            const format = options.format || 'markdown';
+            const conversation = extractConversation({
+                ...options,
+                document: doc,
+                format
+            });
+
+            if (conversation.messages.length === 0) {
+                const message = 'No messages found. The page structure may have changed.';
+                const win = getWindow(doc);
+                if (typeof win?.alert === 'function') win.alert(message);
+                console.warn(`[Chat Exporter] ${message}`);
+                return { conversation, content: '' };
+            }
+
+            const content = render(conversation, format);
+            const filename = options.filename || filenameFor(conversation, format, doc);
+
+            if (options.download !== false) {
+                downloadFile(doc, content, filename, mimeFor(format));
+                console.log(`[Chat Exporter] Exported ${conversation.messages.length} messages to ${filename}`);
+            }
+
+            return { conversation, content, filename };
+        }
+
+        return {
+            version: ENGINE_VERSION,
+            providers: PROVIDERS,
+            detectProvider,
+            extractConversation,
+            exportConversation,
+            serializers: {
+                markdown: renderMarkdown,
+                html: conversation => renderHtmlDocument(conversation, { format: 'html' }),
+                pdf: conversation => renderHtmlDocument(conversation, { format: 'pdf' })
+            },
+            internals: {
+                serializeMessageContent,
+                extractCodeBlock,
+                tableToMarkdown,
+                tableToHtml
+            }
+        };
     });
 
-    // Create and download file
-    const markdownContent = lines.join('\n');
-    const blob = new Blob([markdownContent], { type: 'text/markdown' });
-    const url2 = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url2;
-    // Use document title for better file naming (Issue #12)
-    const safeTitle = document.title.replace(/[<>:"/\\|?*]/g, '').replace(/\s+/g, ' ').trim();
-    a.download = safeTitle ? `${safeTitle} (${date}).md` : `ChatGPT_Conversation_${date}.md`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url2);
-
-    console.log(`Export completed: ${processedMessages.length} messages exported`);
+    globalThis.ChatExporterEngine.exportConversation({
+        provider: 'chatgpt',
+        format: 'markdown'
+    });
 })();

--- a/exporter-markdown.js
+++ b/exporter-markdown.js
@@ -397,7 +397,9 @@
         }
 
         function tableCellText(cell) {
-            return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+            return normalizeWhitespace(getText(cell))
+                .replace(/\\/g, '\\\\')
+                .replace(/\|/g, '\\|') || ' ';
         }
 
         function tableToMarkdown(table) {
@@ -580,7 +582,10 @@
             }
 
             if (tag === 'code') {
-                const content = getCodeText(node).replace(/`/g, '\\`').trim();
+                const content = getCodeText(node)
+                    .replace(/\\/g, '\\\\')
+                    .replace(/`/g, '\\`')
+                    .trim();
                 return content ? `\`${content}\`` : '';
             }
 
@@ -762,7 +767,7 @@
                 const content = serializeMessageContent(contentRoot, format);
                 const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
 
-                if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+                if (!content || normalizeWhitespace(content).length < minLength) return;
 
                 const hash = contentHash(content);
                 if (seen.has(hash)) return;

--- a/exporter-pdf.js
+++ b/exporter-pdf.js
@@ -397,7 +397,9 @@
         }
 
         function tableCellText(cell) {
-            return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+            return normalizeWhitespace(getText(cell))
+                .replace(/\\/g, '\\\\')
+                .replace(/\|/g, '\\|') || ' ';
         }
 
         function tableToMarkdown(table) {
@@ -580,7 +582,10 @@
             }
 
             if (tag === 'code') {
-                const content = getCodeText(node).replace(/`/g, '\\`').trim();
+                const content = getCodeText(node)
+                    .replace(/\\/g, '\\\\')
+                    .replace(/`/g, '\\`')
+                    .trim();
                 return content ? `\`${content}\`` : '';
             }
 
@@ -762,7 +767,7 @@
                 const content = serializeMessageContent(contentRoot, format);
                 const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
 
-                if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+                if (!content || normalizeWhitespace(content).length < minLength) return;
 
                 const hash = contentHash(content);
                 if (seen.has(hash)) return;

--- a/exporter-pdf.js
+++ b/exporter-pdf.js
@@ -1,470 +1,1053 @@
+// Generated from src/extraction-engine.js by scripts/build-exporters.js.
+// Edit the source engine or this build script, then run npm run build.
+
 (() => {
-    // Direct PDF generation without external libraries
-    // This creates a data URL that triggers browser's print-to-PDF dialog
-    
-    function formatDate(date = new Date()) {
-        return date.toISOString().split('T')[0];
-    }
+    'use strict';
 
-    function cleanText(text) {
-        return text
-            .replace(/&/g, '&amp;')  // Replace & first to avoid double-escaping
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;')
-            .trim();
-    }
+    (function initChatExporterEngine(root, factory) {
+        const engine = factory();
 
-    function getText(element) {
-        return (element?.innerText ?? element?.textContent ?? '').trim();
-    }
-
-    function extractCodeBlock(pre) {
-        const codeEl = pre.querySelector('code');
-        const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9_-]+)/);
-        let lang = langMatch ? langMatch[1] : '';
-
-        if (!lang) {
-            const header = pre.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code-block"]');
-            const headerText = getText(header).replace(/\b(copy|code|download)\b/gi, '').trim();
-            if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
-                lang = headerText.toLowerCase();
-            }
-            header?.remove();
+        if (root) {
+            root.ChatExporterEngine = engine;
         }
 
-        const cmContent = pre.querySelector('.cm-content');
-        if (cmContent) {
-            const cmLines = cmContent.querySelectorAll('.cm-line');
-            if (cmLines.length > 0) {
-                return { lang, code: Array.from(cmLines).map(line => line.textContent).join('\n').trim() };
-            }
+        if (typeof module !== 'undefined' && module.exports) {
+            module.exports = engine;
+        }
+    })(typeof globalThis !== 'undefined' ? globalThis : this, function buildChatExporterEngine() {
+        'use strict';
 
-            cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
-            return { lang, code: cmContent.textContent.trim() };
+        const ENGINE_VERSION = '0.7.0-live-engine';
+        const MARKER_PREFIX = '__CHAT_EXPORTER_BLOCK_';
+
+        const PROVIDERS = {
+            chatgpt: {
+                id: 'chatgpt',
+                assistantName: 'ChatGPT',
+                sourceLabel: 'chatgpt.com',
+                defaultTitle: 'Conversation with ChatGPT',
+                genericTitlePattern: /^(chatgpt|new chat|untitled|chat)$/i,
+                messageSelectors: [
+                    'div[data-message-author-role]',
+                    'article[data-testid*="conversation-turn"]',
+                    'div[data-testid="conversation-turn"]',
+                    '.group\\/conversation-turn',
+                    '[data-testid*="message"], [data-message-id], [data-message-author]'
+                ],
+                contentSelectors: [
+                    '.markdown, .prose, [class*="markdown"], [class*="prose"]',
+                    '[data-message-content], [data-testid*="content"]',
+                    '.whitespace-pre-wrap, [class*="whitespace"]'
+                ],
+                titleSelectors: [
+                    'h1:not([class*="hidden"])',
+                    '[class*="conversation-title"]',
+                    '[data-testid*="conversation-title"]'
+                ]
+            },
+            gemini: {
+                id: 'gemini',
+                assistantName: 'Gemini',
+                sourceLabel: 'gemini.google.com',
+                defaultTitle: 'Conversation with Gemini',
+                genericTitlePattern: /^(gemini|new chat|untitled|chat|bard)$/i,
+                messageSelectors: [
+                    'user-query, model-response',
+                    '[data-test-id="conversation-turn"]',
+                    '[data-testid="conversation-turn"]',
+                    '[data-message-author-role]',
+                    '[class*="conversation-turn"]',
+                    '[role="listitem"]'
+                ],
+                contentSelectors: [
+                    'message-content',
+                    '.query-text',
+                    '.response-container',
+                    '.markdown, .prose, [class*="markdown"], [class*="prose"]'
+                ],
+                titleSelectors: [
+                    'h1:not([class*="hidden"])',
+                    '[class*="conversation-title"]',
+                    '[data-testid*="conversation-title"]',
+                    '[aria-label*="conversation"]'
+                ]
+            }
+        };
+
+        function resolveDocument(doc) {
+            if (doc) return doc;
+            if (typeof document !== 'undefined') return document;
+            throw new Error('ChatExporterEngine requires a document.');
         }
 
-        return { lang, code: getText(codeEl || pre) };
-    }
+        function getWindow(doc) {
+            return doc.defaultView || (typeof window !== 'undefined' ? window : null);
+        }
 
-    function addReplacement(replacements, html) {
-        const marker = `EXPORTER_BLOCK_${replacements.length}`;
-        replacements.push({ marker, html });
-        return marker;
-    }
+        function formatDate(date = new Date()) {
+            return date.toISOString().split('T')[0];
+        }
 
-    function processCodeBlocks(clone, replacements) {
-        clone.querySelectorAll('pre').forEach(pre => {
-            const { lang, code } = extractCodeBlock(pre);
-            const label = lang ? `<div class="code-language">${cleanText(lang)}</div>` : '';
-            const html = `<pre class="code-block">${label}<code>${cleanText(code)}</code></pre>`;
-            pre.replaceWith(document.createTextNode(addReplacement(replacements, html)));
-        });
-    }
+        function sanitizeHtml(value) {
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
 
-    function processMath(clone) {
-        const processed = new Set();
+        function normalizeWhitespace(value) {
+            return String(value ?? '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+        }
 
-        clone.querySelectorAll('annotation[encoding*="tex"]').forEach(annotation => {
-            const tex = annotation.textContent.trim();
-            if (!tex) return;
+        function getClassName(element) {
+            const className = element?.className;
+            if (!className) return '';
+            if (typeof className === 'string') return className;
+            return className.baseVal || '';
+        }
 
-            const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
-            const mathRoot = displayRoot || annotation.closest('.katex, mjx-container, math');
-            if (!mathRoot || processed.has(mathRoot)) return;
+        function queryAll(root, selector) {
+            if (!root || !selector) return [];
 
-            processed.add(mathRoot);
-            mathRoot.replaceWith(document.createTextNode(displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
-        });
-
-        clone.querySelectorAll('script[type^="math/tex"]').forEach(script => {
-            const tex = script.textContent.trim();
-            if (!tex) return;
-            const isDisplay = /mode=display/.test(script.type);
-            script.replaceWith(document.createTextNode(isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
-        });
-    }
-
-    function processMedia(clone) {
-        clone.querySelectorAll('img, canvas, video, audio').forEach(el => {
-            const tag = el.tagName.toLowerCase();
-            const alt = el.getAttribute('alt') || el.getAttribute('aria-label') || '';
-            const label = tag === 'img' && alt ? `[Image: ${alt}]` :
-                tag === 'canvas' ? '[Canvas or chart]' :
-                tag === 'video' ? '[Video]' :
-                tag === 'audio' ? '[Audio]' :
-                '[Media]';
-            el.replaceWith(document.createTextNode(label));
-        });
-    }
-
-    function processLinks(clone, replacements) {
-        clone.querySelectorAll('a[href]').forEach(link => {
-            if (link.closest('pre, code')) return;
-
-            const href = (link.href || '').trim();
-            const lowerHref = href.toLowerCase();
-            if (!href || lowerHref.startsWith('javascript:') || lowerHref.startsWith('data:') || lowerHref.startsWith('vbscript:') || href.startsWith('#')) return;
-
-            const text = link.textContent.replace(/\s+/g, ' ').trim() || href;
-            const html = `<a href="${cleanText(href)}">${cleanText(text)}</a>`;
-            link.replaceWith(document.createTextNode(addReplacement(replacements, html)));
-        });
-    }
-
-    function tableToHtml(table) {
-        const rows = Array.from(table.querySelectorAll('tr'))
-            .map(row => Array.from(row.children)
-                .filter(cell => ['TH', 'TD'].includes(cell.tagName))
-                .map(cell => ({ tag: cell.tagName.toLowerCase(), text: getText(cell).replace(/\s+/g, ' ') })))
-            .filter(cells => cells.length > 0);
-
-        if (rows.length === 0) return cleanText(getText(table));
-
-        const renderedRows = rows.map(cells => {
-            const renderedCells = cells.map(cell => `<${cell.tag}>${cleanText(cell.text)}</${cell.tag}>`).join('');
-            return `<tr>${renderedCells}</tr>`;
-        }).join('');
-
-        return `<table>${renderedRows}</table>`;
-    }
-
-    function processTables(clone, replacements) {
-        clone.querySelectorAll('table').forEach(table => {
-            table.replaceWith(document.createTextNode(addReplacement(replacements, tableToHtml(table))));
-        });
-    }
-
-    function restoreReplacements(html, replacements) {
-        return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), html);
-    }
-
-    function findMessages() {
-        const selectors = [
-            'div[data-message-author-role]',
-            'article[data-testid*="conversation-turn"]',
-            'div[data-testid="conversation-turn"]',
-            '.group\\/conversation-turn',
-            'div[class*="group"]:not([class*="group"] [class*="group"])'
-        ];
-
-        let messages = [];
-        for (const selector of selectors) {
-            messages = document.querySelectorAll(selector);
-            if (messages.length > 0) {
-                console.log(`PDF: Using selector: ${selector}, found ${messages.length} messages`);
-                break;
+            try {
+                return Array.from(root.querySelectorAll(selector));
+            } catch (error) {
+                console.warn('[Chat Exporter] Selector failed:', selector, error);
+                return [];
             }
         }
 
-        if (messages.length === 0) {
-            const conversationContainer = document.querySelector('[role="main"], main, .conversation, [class*="conversation"]');
-            if (conversationContainer) {
-                messages = conversationContainer.querySelectorAll(':scope > div, :scope > article');
-                console.log(`PDF: Fallback: found ${messages.length} potential messages`);
+        function matches(element, selector) {
+            if (!element || !selector || typeof element.matches !== 'function') return false;
+
+            try {
+                return element.matches(selector);
+            } catch (error) {
+                return false;
             }
         }
 
-        const validMessages = Array.from(messages).filter(msg => {
-            const text = msg.textContent.trim();
-            return text.length >= 30 && text.length <= 100000;
-        });
+        function getText(element) {
+            if (!element) return '';
+            const innerText = typeof element.innerText === 'string' ? element.innerText : '';
+            return (innerText || element.textContent || '').replace(/\u00a0/g, ' ').trim();
+        }
 
-        const consolidatedMessages = [];
-        const usedElements = new Set();
+        function collectTextWithBreaks(node) {
+            if (!node) return '';
 
-        validMessages.forEach(msg => {
-            if (usedElements.has(msg)) return;
-            
-            const isNested = validMessages.some(other => 
-                other !== msg && other.contains(msg) && !usedElements.has(other)
-            );
-            
-            if (!isNested) {
-                consolidatedMessages.push(msg);
-                usedElements.add(msg);
+            if (node.nodeType === 3) {
+                return node.nodeValue || '';
             }
-        });
 
-        return consolidatedMessages;
-    }
+            if (node.nodeType !== 1) {
+                return '';
+            }
 
-    function identifySender(messageElement, index) {
-        const authorRole = messageElement.getAttribute('data-message-author-role');
-        if (authorRole) {
-            return authorRole === 'user' ? 'You' : 'ChatGPT';
+            const tag = node.tagName.toLowerCase();
+            if (tag === 'br') return '\n';
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+
+            const before = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+            const after = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+            return before + Array.from(node.childNodes).map(collectTextWithBreaks).join('') + after;
         }
 
-        const avatars = messageElement.querySelectorAll('img');
-        for (const avatar of avatars) {
-            const alt = avatar.alt?.toLowerCase() || '';
-            if (alt.includes('user')) return 'You';
-            if (alt.includes('chatgpt') || alt.includes('assistant')) return 'ChatGPT';
+        function getCodeText(element) {
+            if (!element) return '';
+
+            if (typeof element.innerText === 'string' && element.innerText.trim()) {
+                return element.innerText.replace(/\u00a0/g, ' ').replace(/\n{3,}/g, '\n\n').trimEnd();
+            }
+
+            const clone = element.cloneNode(true);
+            queryAll(clone, 'br').forEach(br => br.replaceWith(clone.ownerDocument.createTextNode('\n')));
+            return collectTextWithBreaks(clone).replace(/\n{3,}/g, '\n\n').trimEnd();
         }
 
-        return index % 2 === 0 ? 'You' : 'ChatGPT';
-    }
+        function normalizeCodeText(value) {
+            return String(value ?? '')
+                .replace(/\r\n?/g, '\n')
+                .replace(/^\n+/, '')
+                .replace(/\n+$/, '');
+        }
 
-    function processMessageContent(element) {
-        const clone = element.cloneNode(true);
-        const replacements = [];
+        function createTextNode(reference, text) {
+            return reference.ownerDocument.createTextNode(text);
+        }
 
-        // Do NOT use [class*="edit"]: it matches CodeMirror's "cm-editor" wrapper.
-        clone.querySelectorAll('button, svg, [class*="regenerate"], [data-testid*="copy"], [aria-label*="Copy"], [aria-label*="copy"]').forEach(el => el.remove());
-        processCodeBlocks(clone, replacements);
-        processMath(clone);
-        processMedia(clone);
-        processLinks(clone, replacements);
-        processTables(clone, replacements);
+        function addReplacement(replacements, html) {
+            const marker = `${MARKER_PREFIX}${replacements.length}__`;
+            replacements.push({ marker, html });
+            return marker;
+        }
 
-        const html = cleanText(getText(clone)).replace(/\n/g, '<br>');
-        return restoreReplacements(html, replacements);
-    }
+        function restoreReplacements(value, replacements) {
+            return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), value);
+        }
 
-    function extractTitle() {
-        const titleSelectors = [
-            'h1:not([class*="hidden"])',
-            '[class*="conversation-title"]',
-            '[data-testid*="conversation-title"]'
-        ];
+        function cleanMarkdown(markdown) {
+            return String(markdown ?? '')
+                .split(/(```[\s\S]*?```)/g)
+                .map(part => part.startsWith('```')
+                    ? part
+                    : part
+                        .replace(/[ \t]+\n/g, '\n')
+                        .replace(/\n[ \t]+/g, '\n')
+                        .replace(/\n{3,}/g, '\n\n')
+                        .replace(/&lt;/g, '<')
+                        .replace(/&gt;/g, '>')
+                        .replace(/&amp;/g, '&'))
+                .join('')
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+        }
 
-        for (const selector of titleSelectors) {
-            const element = document.querySelector(selector);
-            if (element && element.textContent.trim()) {
-                const title = element.textContent.trim();
-                if (!['chatgpt', 'new chat', 'untitled'].includes(title.toLowerCase())) {
-                    return title;
+        function escapeMarkdownLinkText(value) {
+            return String(value ?? '')
+                .replace(/\\/g, '\\\\')
+                .replace(/([\[\]])/g, '\\$1');
+        }
+
+        function escapeMarkdownUrl(value) {
+            return String(value ?? '')
+                .replace(/\\/g, '%5C')
+                .replace(/\)/g, '%29');
+        }
+
+        function isUnsafeHref(href) {
+            const lower = String(href || '').trim().toLowerCase();
+            return !lower ||
+                lower.startsWith('javascript:') ||
+                lower.startsWith('data:') ||
+                lower.startsWith('vbscript:') ||
+                lower.startsWith('#');
+        }
+
+        function topLevelElements(elements) {
+            return elements.filter(element => !elements.some(other => other !== element && other.contains(element)));
+        }
+
+        function removeUiElements(clone) {
+            const uiSelector = [
+                'button',
+                'svg',
+                'style',
+                'script',
+                'textarea',
+                'input',
+                '[contenteditable="true"]',
+                '[class*="regenerate"]',
+                '[class*="copy-button"]',
+                '[data-testid*="copy"]',
+                '[data-test-id*="copy"]',
+                '[aria-label*="Copy"]',
+                '[aria-label*="copy"]',
+                '[aria-label*="More"]',
+                '[aria-label*="more"]'
+            ].join(',');
+
+            queryAll(clone, uiSelector).forEach(element => element.remove());
+        }
+
+        function detectLanguage(block) {
+            const codeElement = matches(block, 'code') ? block : block.querySelector('code');
+            const sources = [
+                codeElement?.className,
+                block.getAttribute?.('data-language'),
+                block.getAttribute?.('language'),
+                block.getAttribute?.('lang'),
+                codeElement?.getAttribute?.('data-language'),
+                codeElement?.getAttribute?.('language'),
+                codeElement?.getAttribute?.('lang'),
+                block.getAttribute?.('aria-label')
+            ].filter(Boolean).map(String);
+
+            for (const source of sources) {
+                const languageMatch = source.match(/language-([a-zA-Z0-9_+#.-]+)/);
+                if (languageMatch) return languageMatch[1].toLowerCase();
+                if (/^[a-zA-Z0-9_+#.-]{1,24}$/.test(source) && !/^(code|copy|download)$/i.test(source)) {
+                    return source.toLowerCase();
                 }
             }
-        }
-        
-        const docTitle = document.title;
-        if (docTitle && !docTitle.toLowerCase().includes('chatgpt')) {
-            return docTitle;
-        }
-        
-        return 'ChatGPT Conversation';
-    }
 
-    // Main export logic
-    const messages = findMessages();
-    
-    if (messages.length === 0) {
-        alert('No messages found. The page structure may have changed.');
-        return;
-    }
-
-    console.log(`PDF: Processing ${messages.length} messages...`);
-
-    const title = extractTitle();
-    const date = formatDate();
-    const url = window.location.href;
-
-    // Create HTML content optimized for PDF printing
-    let htmlContent = `<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>${cleanText(title)}</title>
-    <style>
-        @media print {
-            body { margin: 0; }
-            .no-print { display: none; }
-            .message { page-break-inside: avoid; }
-        }
-        
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 800px;
-            margin: 0 auto;
-            padding: 40px 20px;
-            background: white;
-        }
-        
-        h1 {
-            color: #2c3e50;
-            border-bottom: 3px solid #3498db;
-            padding-bottom: 10px;
-            margin-bottom: 30px;
-        }
-        
-        .metadata {
-            color: #666;
-            font-size: 14px;
-            margin-bottom: 30px;
-            padding-bottom: 20px;
-            border-bottom: 1px solid #e0e0e0;
-        }
-        
-        .message {
-            margin: 25px 0;
-            padding: 20px;
-            background: #f8f9fa;
-            border-radius: 8px;
-            page-break-inside: avoid;
-        }
-        
-        .message.user {
-            background: #e3f2fd;
-            margin-left: 40px;
-        }
-        
-        .message.assistant {
-            background: #f3f4f6;
-            margin-right: 40px;
-        }
-        
-        .sender {
-            font-weight: bold;
-            color: #2c3e50;
-            margin-bottom: 10px;
-            font-size: 14px;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        
-        .content {
-            color: #333;
-            white-space: pre-wrap;
-            word-wrap: break-word;
-        }
-        
-        .code-block {
-            background: #282c34;
-            color: #abb2bf;
-            padding: 15px;
-            border-radius: 5px;
-            overflow-x: auto;
-            font-family: "Courier New", monospace;
-            font-size: 14px;
-            margin: 10px 0;
-        }
-
-        .code-block code {
-            white-space: pre;
-        }
-
-        .code-language {
-            color: #d7dae0;
-            font-size: 12px;
-            margin-bottom: 8px;
-            text-transform: uppercase;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            margin: 12px 0;
-            font-size: 14px;
-        }
-
-        th, td {
-            border: 1px solid #d9dde3;
-            padding: 8px;
-            text-align: left;
-            vertical-align: top;
-        }
-
-        th {
-            background: #eef2f7;
-        }
-        
-        .instructions {
-            background: #fff3cd;
-            border: 2px solid #ffc107;
-            border-radius: 8px;
-            padding: 20px;
-            margin: 30px 0;
-        }
-        
-        .instructions h3 {
-            margin-top: 0;
-            color: #856404;
-        }
-        
-        @media screen {
-            .instructions {
-                position: sticky;
-                top: 20px;
-                z-index: 1000;
+            const header = block.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code"], [data-test-id*="code"], .code-language, .code-lang, [slot="header"]');
+            const headerText = normalizeWhitespace(getText(header)).replace(/\b(copy|code|download)\b/gi, '').trim();
+            if (headerText && headerText.length < 32 && !headerText.includes('\n')) {
+                return headerText.toLowerCase();
             }
+
+            return '';
         }
-    </style>
-</head>
-<body>
-    <div class="instructions no-print">
-        <h3>📄 Convert to PDF</h3>
-        <ol>
-            <li>Press <strong>Ctrl+P</strong> (Windows/Linux) or <strong>Cmd+P</strong> (Mac)</li>
-            <li>Set "Destination" to <strong>"Save as PDF"</strong></li>
-            <li>Choose your preferred settings (recommend "Letter" or "A4" size)</li>
-            <li>Click <strong>"Save"</strong></li>
-        </ol>
-        <p><em>This instruction box will not appear in the PDF.</em></p>
-    </div>
 
-    <h1>${cleanText(title)}</h1>
-    
-    <div class="metadata">
-        <p><strong>Date:</strong> ${date}</p>
-        <p><strong>Source:</strong> <a href="${url}">${url}</a></p>
-        <p><strong>Messages:</strong> ${messages.length}</p>
-    </div>
-    
-    <div class="conversation">`;
+        function extractCodeBlock(block) {
+            const clone = block.cloneNode(true);
+            const language = detectLanguage(clone);
 
-    // Process messages
-    const seenContent = new Set();
-    let processedCount = 0;
+            queryAll(clone, 'button, svg, [aria-label*="Copy"], [aria-label*="copy"], [class*="sticky"], [class*="code-header"], [data-testid*="copy"], [data-test-id*="copy"], [slot="header"]').forEach(element => element.remove());
 
-    messages.forEach((messageElement, index) => {
-        const sender = identifySender(messageElement, index);
-        const content = processMessageContent(messageElement);
-        
-        if (!content || content.replace(/<[^>]*>/g, '').trim().length < 10) return;
-        
-        const contentHash = content.replace(/<[^>]*>/g, ' ').substring(0, 100).replace(/\s+/g, ' ');
-        if (seenContent.has(contentHash)) return;
-        seenContent.add(contentHash);
-        
-        const senderClass = sender.toLowerCase() === 'you' ? 'user' : 'assistant';
-        
-        htmlContent += `
-        <div class="message ${senderClass}">
-            <div class="sender">${cleanText(sender)}</div>
-            <div class="content">${content}</div>
-        </div>`;
-        
-        processedCount++;
+            const cmContent = clone.querySelector('.cm-content');
+            if (cmContent) {
+                const cmLines = queryAll(cmContent, '.cm-line');
+                if (cmLines.length > 0) {
+                    return {
+                        lang: language,
+                        code: normalizeCodeText(cmLines.map(line => line.textContent || '').join('\n'))
+                    };
+                }
+
+                return {
+                    lang: language,
+                    code: normalizeCodeText(getCodeText(cmContent))
+                };
+            }
+
+            const codeElement = matches(clone, 'code') ? clone : clone.querySelector('code');
+            return {
+                lang: language,
+                code: normalizeCodeText(getCodeText(codeElement || clone))
+            };
+        }
+
+        function formatCodeBlock(block, format, replacements) {
+            const { lang, code } = extractCodeBlock(block);
+
+            if (format === 'markdown') {
+                return `\n\n\`\`\`${lang}\n${code}\n\`\`\`\n\n`;
+            }
+
+            const langClass = lang ? ` class="language-${sanitizeHtml(lang)}"` : '';
+            if (format === 'pdf') {
+                const label = lang ? `<div class="code-language">${sanitizeHtml(lang)}</div>` : '';
+                return addReplacement(replacements, `<pre class="code-block">${label}<code>${sanitizeHtml(code)}</code></pre>`);
+            }
+
+            return addReplacement(replacements, `<pre><code${langClass}>${sanitizeHtml(code)}</code></pre>`);
+        }
+
+        function processCodeBlocks(clone, format, replacements) {
+            const blocks = topLevelElements(queryAll(clone, 'pre, code-block, [data-testid*="code-block"], [data-test-id*="code-block"]'));
+
+            blocks.forEach(block => {
+                const replacement = formatCodeBlock(block, format, replacements);
+                block.replaceWith(createTextNode(block, replacement));
+            });
+        }
+
+        function processMath(clone) {
+            const processed = new Set();
+
+            queryAll(clone, 'annotation').forEach(annotation => {
+                const encoding = (annotation.getAttribute('encoding') || '').toLowerCase();
+                if (!encoding.includes('tex') && !encoding.includes('latex')) return;
+
+                const tex = annotation.textContent.trim();
+                if (!tex) return;
+
+                const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
+                const mathRoot = displayRoot || annotation.closest('.katex') || annotation.closest('mjx-container') || annotation.closest('math');
+                if (!mathRoot || processed.has(mathRoot)) return;
+
+                processed.add(mathRoot);
+                mathRoot.replaceWith(createTextNode(mathRoot, displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+            });
+
+            queryAll(clone, 'script[type^="math/tex"]').forEach(script => {
+                const tex = script.textContent.trim();
+                if (!tex) return;
+                const isDisplay = /mode=display/.test(script.type);
+                script.replaceWith(createTextNode(script, isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+            });
+        }
+
+        function processMedia(clone, format, replacements) {
+            queryAll(clone, 'img, canvas, video, audio').forEach(element => {
+                const tag = element.tagName.toLowerCase();
+                const alt = normalizeWhitespace(element.getAttribute('alt') || element.getAttribute('aria-label') || element.getAttribute('title') || '');
+                const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                    tag === 'img' ? '[Image]' :
+                    tag === 'canvas' ? '[Canvas or chart]' :
+                    tag === 'video' ? '[Video]' :
+                    tag === 'audio' ? '[Audio]' :
+                    '[Media]';
+
+                const replacement = format === 'markdown'
+                    ? label
+                    : addReplacement(replacements, `<span class="media-placeholder">${sanitizeHtml(label)}</span>`);
+                element.replaceWith(createTextNode(element, replacement));
+            });
+        }
+
+        function processLinks(clone, format, replacements) {
+            queryAll(clone, 'a[href]').forEach(link => {
+                if (link.closest('pre, code, code-block')) return;
+
+                const href = String(link.href || link.getAttribute('href') || '').trim();
+                if (isUnsafeHref(href)) return;
+
+                const text = normalizeWhitespace(link.textContent) || href;
+                const replacement = format === 'markdown'
+                    ? `[${escapeMarkdownLinkText(text)}](${escapeMarkdownUrl(href)})`
+                    : addReplacement(replacements, `<a href="${sanitizeHtml(href)}">${sanitizeHtml(text)}</a>`);
+
+                link.replaceWith(createTextNode(link, replacement));
+            });
+        }
+
+        function tableCellText(cell) {
+            return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+        }
+
+        function tableToMarkdown(table) {
+            const rows = queryAll(table, 'tr')
+                .map(row => Array.from(row.children)
+                    .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                    .map(tableCellText))
+                .filter(row => row.length > 0);
+
+            if (rows.length === 0) return normalizeWhitespace(getText(table));
+
+            const width = Math.max(...rows.map(row => row.length));
+            const normalizedRows = rows.map(row => row.concat(Array(Math.max(0, width - row.length)).fill(' ')));
+            const header = normalizedRows[0];
+            const separator = header.map(() => '---');
+            const body = normalizedRows.slice(1);
+
+            return [
+                `| ${header.join(' | ')} |`,
+                `| ${separator.join(' | ')} |`,
+                ...body.map(row => `| ${row.join(' | ')} |`)
+            ].join('\n');
+        }
+
+        function tableToHtml(table) {
+            const rows = queryAll(table, 'tr')
+                .map(row => Array.from(row.children)
+                    .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                    .map(cell => ({
+                        tag: cell.tagName.toLowerCase(),
+                        text: normalizeWhitespace(getText(cell))
+                    })))
+                .filter(row => row.length > 0);
+
+            if (rows.length === 0) return sanitizeHtml(getText(table));
+
+            return `<table>${rows.map(row => {
+                const cells = row.map(cell => `<${cell.tag}>${sanitizeHtml(cell.text)}</${cell.tag}>`).join('');
+                return `<tr>${cells}</tr>`;
+            }).join('')}</table>`;
+        }
+
+        function processTables(clone, format, replacements) {
+            topLevelElements(queryAll(clone, 'table')).forEach(table => {
+                const replacement = format === 'markdown'
+                    ? `\n\n${tableToMarkdown(table)}\n\n`
+                    : addReplacement(replacements, tableToHtml(table));
+                table.replaceWith(createTextNode(table, replacement));
+            });
+        }
+
+        function cardSignal(element) {
+            const pieces = [
+                element.tagName,
+                getClassName(element),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id'),
+                element.getAttribute('aria-label'),
+                element.getAttribute('role')
+            ].filter(Boolean).join(' ').toLowerCase();
+
+            if (/\b(artifact|canvas-preview|generated-file|download-card|attachment|file-card)\b/.test(pieces)) {
+                return pieces.includes('artifact') || pieces.includes('canvas-preview') ? 'Artifact' : 'File';
+            }
+
+            if (/(^|[\s_-])(attachment|file)([\s_-]|$)/.test(pieces)) {
+                return 'File';
+            }
+
+            return '';
+        }
+
+        function cardLabel(element) {
+            const candidates = [
+                element.getAttribute('aria-label'),
+                element.getAttribute('title'),
+                element.getAttribute('download'),
+                element.getAttribute('data-filename'),
+                getText(element)
+            ].filter(Boolean).map(normalizeWhitespace);
+
+            const label = candidates.find(value => value && value.length <= 180) || '';
+            return label
+                .replace(/\b(open|download|preview|file|attachment|artifact)\b/gi, ' ')
+                .replace(/\s+/g, ' ')
+                .trim();
+        }
+
+        function processCards(clone, format, replacements) {
+            const cards = topLevelElements(Array.from(clone.querySelectorAll('*')).filter(element => {
+                const kind = cardSignal(element);
+                if (!kind) return false;
+                if (matches(element, '[data-message-author-role], user-query, model-response')) return false;
+                if (element.closest('pre, code, code-block, table')) return false;
+                if (element.querySelector('pre, code-block, table, user-query, model-response')) return false;
+
+                const text = normalizeWhitespace(getText(element));
+                const label = cardLabel(element);
+                return Boolean(label || text) && text.length <= 240;
+            }));
+
+            cards.forEach(card => {
+                const kind = cardSignal(card);
+                const label = cardLabel(card);
+                const text = label ? `[${kind}: ${label}]` : `[${kind}]`;
+                const replacement = format === 'markdown'
+                    ? text
+                    : addReplacement(replacements, `<span class="card-placeholder">${sanitizeHtml(text)}</span>`);
+                card.replaceWith(createTextNode(card, replacement));
+            });
+        }
+
+        function serializeMarkdownChildren(element, context = {}) {
+            return Array.from(element.childNodes).map((node, index) => serializeMarkdownNode(node, {
+                ...context,
+                index
+            })).join('');
+        }
+
+        function serializeMarkdownNode(node, context = {}) {
+            if (node.nodeType === 3) {
+                const value = node.nodeValue || '';
+                if (value.includes('```') || value.includes('| ---') || value.includes(MARKER_PREFIX) || value.match(/^\s*\[[^\]]+\]/)) {
+                    return value;
+                }
+                return value.replace(/[ \t\r\n]+/g, ' ');
+            }
+
+            if (node.nodeType !== 1) return '';
+
+            const tag = node.tagName.toLowerCase();
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+            if (tag === 'br') return '\n';
+
+            if (/^h[1-6]$/.test(tag)) {
+                const level = Number(tag.slice(1));
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${'#'.repeat(level)} ${content}\n\n` : '';
+            }
+
+            if (tag === 'p') {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${content}\n\n` : '';
+            }
+
+            if (tag === 'blockquote') {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${content.split('\n').map(line => `> ${line.trim()}`).join('\n')}\n\n` : '';
+            }
+
+            if (tag === 'ul' || tag === 'ol') {
+                const children = Array.from(node.children).filter(child => child.tagName && child.tagName.toLowerCase() === 'li');
+                return `\n${children.map((child, index) => serializeMarkdownNode(child, {
+                    ...context,
+                    listType: tag,
+                    index,
+                    depth: (context.depth || 0)
+                })).join('')}\n`;
+            }
+
+            if (tag === 'li') {
+                const depth = context.depth || 0;
+                const marker = context.listType === 'ol' ? `${(context.index || 0) + 1}. ` : '- ';
+                const indent = '  '.repeat(depth);
+                const content = serializeMarkdownChildren(node, {
+                    ...context,
+                    depth: depth + 1
+                }).trim();
+                return content ? `${indent}${marker}${content.replace(/\n+/g, `\n${indent}  `)}\n` : '';
+            }
+
+            if (['strong', 'b'].includes(tag)) {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `**${content}**` : '';
+            }
+
+            if (['em', 'i'].includes(tag)) {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `*${content}*` : '';
+            }
+
+            if (tag === 'code') {
+                const content = getCodeText(node).replace(/`/g, '\\`').trim();
+                return content ? `\`${content}\`` : '';
+            }
+
+            const content = serializeMarkdownChildren(node, context);
+            if (['div', 'section', 'article', 'main', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+                return content;
+            }
+
+            return content;
+        }
+
+        function serializeHtmlChildren(element, replacements) {
+            return Array.from(element.childNodes).map(node => serializeHtmlNode(node, replacements)).join('');
+        }
+
+        function serializeHtmlNode(node, replacements) {
+            if (node.nodeType === 3) {
+                return sanitizeHtml(node.nodeValue || '');
+            }
+
+            if (node.nodeType !== 1) return '';
+
+            const tag = node.tagName.toLowerCase();
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+            if (tag === 'br') return '<br>';
+
+            const content = serializeHtmlChildren(node, replacements);
+            const blockTags = new Set(['p', 'ul', 'ol', 'li', 'blockquote', 'strong', 'b', 'em', 'i']);
+
+            if (/^h[1-6]$/.test(tag)) {
+                return `<${tag}>${content}</${tag}>`;
+            }
+
+            if (blockTags.has(tag)) {
+                const safeTag = tag === 'b' ? 'strong' : tag === 'i' ? 'em' : tag;
+                return `<${safeTag}>${content}</${safeTag}>`;
+            }
+
+            if (tag === 'code') {
+                return `<code>${sanitizeHtml(getCodeText(node).trim())}</code>`;
+            }
+
+            if (['div', 'section', 'article', 'main', 'span', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+                return content;
+            }
+
+            return content;
+        }
+
+        function serializeMessageContent(element, format) {
+            const clone = element.cloneNode(true);
+            const replacements = [];
+
+            removeUiElements(clone);
+            processCards(clone, format, replacements);
+            processCodeBlocks(clone, format, replacements);
+            processMath(clone);
+            processMedia(clone, format, replacements);
+            processLinks(clone, format, replacements);
+            processTables(clone, format, replacements);
+
+            if (format === 'markdown') {
+                return cleanMarkdown(serializeMarkdownChildren(clone));
+            }
+
+            const html = serializeHtmlChildren(clone, replacements)
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+            return restoreReplacements(html, replacements);
+        }
+
+        function detectProvider(doc) {
+            const url = doc.defaultView?.location?.href || '';
+            if (/gemini\.google\.com/i.test(url) || doc.querySelector('user-query, model-response')) return 'gemini';
+            return 'chatgpt';
+        }
+
+        function providerFor(providerName, doc) {
+            const id = providerName || detectProvider(doc);
+            return PROVIDERS[id] || PROVIDERS.chatgpt;
+        }
+
+        function meaningfulScore(element) {
+            const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+            return normalizeWhitespace(element.textContent).length + richCount * 200;
+        }
+
+        function isValidMessage(element) {
+            const text = normalizeWhitespace(element.textContent);
+            const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+
+            if (text.length < 5 && richCount === 0) return false;
+            if (text.length > 200000) return false;
+            if (matches(element, 'nav, aside, header, footer, form, menu')) return false;
+            if (element.querySelector('textarea, input[type="text"], [contenteditable="true"]') && !element.hasAttribute('data-message-author-role')) return false;
+            if (getClassName(element).match(/\b(typing|loading|spinner)\b/i)) return false;
+
+            return true;
+        }
+
+        function findMessages(doc, provider) {
+            for (const selector of provider.messageSelectors) {
+                const messages = topLevelElements(queryAll(doc, selector)).filter(isValidMessage);
+                if (messages.length > 0) {
+                    console.log(`[Chat Exporter] ${provider.id}: using selector "${selector}" (${messages.length} messages)`);
+                    return messages;
+                }
+            }
+
+            const container = doc.querySelector('[role="main"], main, [class*="conversation"], [class*="chat"]');
+            if (!container) return [];
+
+            return topLevelElements(queryAll(container, ':scope > article, :scope > section, :scope > div')).filter(isValidMessage);
+        }
+
+        function selectContentRoot(messageElement, provider) {
+            const candidates = [messageElement];
+
+            provider.contentSelectors.forEach(selector => {
+                if (matches(messageElement, selector)) candidates.push(messageElement);
+                candidates.push(...queryAll(messageElement, selector));
+            });
+
+            return candidates
+                .filter(Boolean)
+                .sort((a, b) => meaningfulScore(b) - meaningfulScore(a))[0] || messageElement;
+        }
+
+        function identifySender(element, index, provider) {
+            const tag = element.tagName.toLowerCase();
+            if (tag === 'user-query') return { sender: 'You', reliable: true };
+            if (tag === 'model-response') return { sender: provider.assistantName, reliable: true };
+
+            const role = element.getAttribute('data-message-author-role') || element.getAttribute('data-author') || element.getAttribute('data-sender');
+            if (role) {
+                const normalizedRole = role.toLowerCase();
+                if (normalizedRole === 'user') return { sender: 'You', reliable: true };
+                if (['assistant', 'model', 'bot', 'chatgpt', 'gemini'].includes(normalizedRole)) {
+                    return { sender: provider.assistantName, reliable: true };
+                }
+            }
+
+            const classAndAttrs = [
+                getClassName(element),
+                element.getAttribute('aria-label'),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id')
+            ].filter(Boolean).join(' ').toLowerCase();
+
+            if (classAndAttrs.match(/\b(user|human|query)\b/)) return { sender: 'You', reliable: false };
+            if (classAndAttrs.match(/\b(assistant|model|response|chatgpt|gemini|bard)\b/)) return { sender: provider.assistantName, reliable: false };
+
+            const textStart = normalizeWhitespace(element.textContent).slice(0, 220).toLowerCase();
+            if (/^(i understand|i can help|here's|i'll|let me|i'd be happy|certainly|of course|absolutely)/.test(textStart)) {
+                return { sender: provider.assistantName, reliable: false };
+            }
+
+            if (/^(can you|please help|how do i|i need|i want|help me|could you|explain|what is)/.test(textStart)) {
+                return { sender: 'You', reliable: false };
+            }
+
+            return { sender: index % 2 === 0 ? 'You' : provider.assistantName, reliable: false };
+        }
+
+        function contentHash(content) {
+            return normalizeWhitespace(String(content || '').replace(/<[^>]+>/g, ' ')).slice(0, 160);
+        }
+
+        function extractConversation(options = {}) {
+            const doc = resolveDocument(options.document);
+            const provider = providerFor(options.provider, doc);
+            const format = options.format || 'markdown';
+            const rawMessages = findMessages(doc, provider);
+            const seen = new Set();
+            const messages = [];
+
+            rawMessages.forEach((messageElement, index) => {
+                const contentRoot = selectContentRoot(messageElement, provider);
+                const content = serializeMessageContent(contentRoot, format);
+                const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
+
+                if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+
+                const hash = contentHash(content);
+                if (seen.has(hash)) return;
+                seen.add(hash);
+
+                const sender = identifySender(messageElement, index, provider);
+                messages.push({
+                    sender: sender.sender,
+                    senderType: sender.sender === 'You' ? 'user' : 'assistant',
+                    reliableSender: sender.reliable,
+                    content,
+                    index
+                });
+            });
+
+            return {
+                version: ENGINE_VERSION,
+                provider: provider.id,
+                providerLabel: provider.assistantName,
+                sourceLabel: provider.sourceLabel,
+                title: extractConversationTitle(doc, provider),
+                sourceUrl: doc.defaultView?.location?.href || '',
+                date: formatDate(options.date || new Date()),
+                messages
+            };
+        }
+
+        function extractConversationTitle(doc, provider) {
+            for (const selector of provider.titleSelectors) {
+                const element = doc.querySelector(selector);
+                const title = normalizeWhitespace(element?.textContent);
+                if (title && !provider.genericTitlePattern.test(title)) return title;
+            }
+
+            const docTitle = normalizeWhitespace(doc.title);
+            if (docTitle && !provider.genericTitlePattern.test(docTitle)) return docTitle;
+
+            return provider.defaultTitle;
+        }
+
+        function renderMarkdown(conversation) {
+            const lines = [
+                `# ${conversation.title}\n`,
+                `**Date:** ${conversation.date}`,
+                `**Source:** [${conversation.sourceLabel}](${conversation.sourceUrl})\n`,
+                '---\n'
+            ];
+
+            conversation.messages.forEach(message => {
+                lines.push(`### **${message.sender}**\n`, message.content, '\n---\n');
+            });
+
+            return `${lines.join('\n').trim()}\n`;
+        }
+
+        function renderHtmlDocument(conversation, options = {}) {
+            const isPdf = options.format === 'pdf';
+            const source = sanitizeHtml(conversation.sourceUrl);
+            const title = sanitizeHtml(conversation.title);
+            const messages = conversation.messages.map(message => {
+                const senderClass = message.senderType === 'user' ? 'user' : 'assistant';
+                return `
+            <div class="message ${senderClass}">
+                <div class="sender">${sanitizeHtml(message.sender)}</div>
+                <div class="content">${message.content}</div>
+            </div>`;
+            }).join('');
+
+            const pdfInstructions = isPdf ? `
+        <div class="instructions no-print">
+            <h3>Convert to PDF</h3>
+            <ol>
+                <li>Press Ctrl+P on Windows/Linux or Cmd+P on Mac.</li>
+                <li>Set Destination to Save as PDF.</li>
+                <li>Choose your preferred page size.</li>
+                <li>Click Save.</li>
+            </ol>
+            <p><em>This instruction box will not appear in the PDF.</em></p>
+        </div>` : '';
+
+            return `<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <title>${title} - ${conversation.date}</title>
+        <style>
+            @media print {
+                body { margin: 0; }
+                .no-print { display: none; }
+                .message { page-break-inside: avoid; }
+            }
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+                max-width: 840px;
+                margin: auto;
+                padding: 2rem;
+                background: #fff;
+                color: #333;
+                line-height: 1.6;
+            }
+            .header {
+                text-align: center;
+                margin-bottom: 2rem;
+                padding-bottom: 1rem;
+                border-bottom: 2px solid #eee;
+            }
+            .metadata {
+                color: #666;
+                font-size: 0.9rem;
+            }
+            .message {
+                margin-bottom: 1.5rem;
+                padding: 1rem;
+                border-radius: 8px;
+                background: #f8f9fa;
+            }
+            .message.user {
+                background: #eaf4ff;
+            }
+            .sender {
+                font-weight: 700;
+                color: #2c3e50;
+                margin-bottom: 0.5rem;
+            }
+            .content {
+                white-space: pre-wrap;
+                overflow-wrap: anywhere;
+            }
+            pre {
+                background: #f4f4f4;
+                padding: 1rem;
+                border-radius: 4px;
+                overflow-x: auto;
+                border-left: 4px solid #007acc;
+            }
+            .code-block {
+                background: #282c34;
+                color: #abb2bf;
+                border-left: 0;
+            }
+            .code-block code {
+                white-space: pre;
+            }
+            .code-language {
+                color: #d7dae0;
+                font-size: 12px;
+                margin-bottom: 8px;
+                text-transform: uppercase;
+            }
+            code {
+                font-family: Consolas, Monaco, "Courier New", monospace;
+                font-size: 0.92rem;
+            }
+            table {
+                width: 100%;
+                border-collapse: collapse;
+                margin: 1rem 0;
+            }
+            th, td {
+                border: 1px solid #d9dde3;
+                padding: 0.5rem;
+                text-align: left;
+                vertical-align: top;
+            }
+            th {
+                background: #eef2f7;
+            }
+            .instructions {
+                background: #fff8dc;
+                border: 1px solid #e3c565;
+                border-radius: 8px;
+                padding: 1rem;
+                margin-bottom: 1.5rem;
+            }
+        </style>
+    </head>
+    <body>
+        ${pdfInstructions}
+        <div class="header">
+            <h1>${title}</h1>
+            <div class="metadata">
+                <div><strong>Date:</strong> ${sanitizeHtml(conversation.date)}</div>
+                <div><strong>Source:</strong> <a href="${source}">${sanitizeHtml(conversation.sourceLabel)}</a></div>
+                <div><strong>Messages:</strong> ${conversation.messages.length}</div>
+            </div>
+        </div>
+        <div class="conversation">${messages}
+        </div>
+    </body>
+    </html>`;
+        }
+
+        function render(conversation, format) {
+            if (format === 'markdown') return renderMarkdown(conversation);
+            if (format === 'pdf') return renderHtmlDocument(conversation, { format: 'pdf' });
+            if (format === 'html') return renderHtmlDocument(conversation, { format: 'html' });
+            throw new Error(`Unsupported export format: ${format}`);
+        }
+
+        function filenameFor(conversation, format, doc) {
+            const safeTitle = normalizeWhitespace(doc.title || conversation.title)
+                .replace(/[<>:"/\\|?*]/g, '')
+                .slice(0, 120);
+
+            if (format === 'markdown') {
+                return safeTitle ? `${safeTitle} (${conversation.date}).md` : `${conversation.providerLabel}_Conversation_${conversation.date}.md`;
+            }
+
+            if (format === 'pdf') {
+                return safeTitle ? `${safeTitle} (${conversation.date}) - PrintToPDF.html` : `${conversation.providerLabel}_Conversation_${conversation.date}_PrintToPDF.html`;
+            }
+
+            return safeTitle ? `${safeTitle} (${conversation.date}).html` : `${conversation.providerLabel}_Conversation_${conversation.date}.html`;
+        }
+
+        function mimeFor(format) {
+            return format === 'markdown' ? 'text/markdown' : 'text/html';
+        }
+
+        function downloadFile(doc, content, filename, mimeType) {
+            const win = getWindow(doc);
+            const BlobCtor = win?.Blob || Blob;
+            const urlApi = win?.URL || URL;
+            const blob = new BlobCtor([content], { type: mimeType });
+            const url = urlApi.createObjectURL(blob);
+            const anchor = doc.createElement('a');
+
+            anchor.href = url;
+            anchor.download = filename;
+            doc.body.appendChild(anchor);
+            anchor.click();
+            doc.body.removeChild(anchor);
+            urlApi.revokeObjectURL(url);
+        }
+
+        function exportConversation(options = {}) {
+            const doc = resolveDocument(options.document);
+            const format = options.format || 'markdown';
+            const conversation = extractConversation({
+                ...options,
+                document: doc,
+                format
+            });
+
+            if (conversation.messages.length === 0) {
+                const message = 'No messages found. The page structure may have changed.';
+                const win = getWindow(doc);
+                if (typeof win?.alert === 'function') win.alert(message);
+                console.warn(`[Chat Exporter] ${message}`);
+                return { conversation, content: '' };
+            }
+
+            const content = render(conversation, format);
+            const filename = options.filename || filenameFor(conversation, format, doc);
+
+            if (options.download !== false) {
+                downloadFile(doc, content, filename, mimeFor(format));
+                console.log(`[Chat Exporter] Exported ${conversation.messages.length} messages to ${filename}`);
+            }
+
+            return { conversation, content, filename };
+        }
+
+        return {
+            version: ENGINE_VERSION,
+            providers: PROVIDERS,
+            detectProvider,
+            extractConversation,
+            exportConversation,
+            serializers: {
+                markdown: renderMarkdown,
+                html: conversation => renderHtmlDocument(conversation, { format: 'html' }),
+                pdf: conversation => renderHtmlDocument(conversation, { format: 'pdf' })
+            },
+            internals: {
+                serializeMessageContent,
+                extractCodeBlock,
+                tableToMarkdown,
+                tableToHtml
+            }
+        };
     });
 
-    htmlContent += `
-    </div>
-</body>
-</html>`;
-
-    // Create blob and download
-    const blob = new Blob([htmlContent], { type: 'text/html' });
-    const url2 = URL.createObjectURL(blob);
-    
-    // Create download link
-    const a = document.createElement('a');
-    a.href = url2;
-    const safeTitle = document.title.replace(/[<>:"/\\|?*]/g, '').replace(/\s+/g, ' ').trim();
-    a.download = safeTitle ? `${safeTitle} (${date}) - PrintToPDF.html` : `ChatGPT_Conversation_${date}_PrintToPDF.html`;
-    
-    // Auto-download
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url2);
-
-    console.log(`PDF: Export completed - ${processedCount} messages processed`);
-    console.log('PDF: The HTML file has been downloaded. Open it and press Ctrl+P (Cmd+P on Mac) to save as PDF.');
-    
-    // Show instructions
-    alert(`✅ Export Complete!\n\n${processedCount} messages exported.\n\nTo create PDF:\n1. Open the downloaded HTML file\n2. Press Ctrl+P (Cmd+P on Mac)\n3. Choose "Save as PDF"\n4. Click Save\n\nThe yellow instruction box will not appear in the PDF.`);
+    globalThis.ChatExporterEngine.exportConversation({
+        provider: 'chatgpt',
+        format: 'pdf'
+    });
 })();

--- a/gemini-exporter-markdown.js
+++ b/gemini-exporter-markdown.js
@@ -397,7 +397,9 @@
         }
 
         function tableCellText(cell) {
-            return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+            return normalizeWhitespace(getText(cell))
+                .replace(/\\/g, '\\\\')
+                .replace(/\|/g, '\\|') || ' ';
         }
 
         function tableToMarkdown(table) {
@@ -580,7 +582,10 @@
             }
 
             if (tag === 'code') {
-                const content = getCodeText(node).replace(/`/g, '\\`').trim();
+                const content = getCodeText(node)
+                    .replace(/\\/g, '\\\\')
+                    .replace(/`/g, '\\`')
+                    .trim();
                 return content ? `\`${content}\`` : '';
             }
 
@@ -762,7 +767,7 @@
                 const content = serializeMessageContent(contentRoot, format);
                 const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
 
-                if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+                if (!content || normalizeWhitespace(content).length < minLength) return;
 
                 const hash = contentHash(content);
                 if (seen.has(hash)) return;

--- a/gemini-exporter-markdown.js
+++ b/gemini-exporter-markdown.js
@@ -1,495 +1,1053 @@
+// Generated from src/extraction-engine.js by scripts/build-exporters.js.
+// Edit the source engine or this build script, then run npm run build.
+
 (() => {
     'use strict';
 
-    // Configuration object for easy maintenance
-    const CONFIG = {
-        selectors: {
-            messages: [
-                'user-query, model-response',
-                '[data-test-id="conversation-turn"]',
-                '[data-testid="conversation-turn"]',
-                '[data-message-author-role]',
-                '[class*="conversation-turn"]',
-                '[role="listitem"]',
-                '[role="presentation"] > div',
-                '.conversation-container > div'
-            ],
-            title: [
-                'h1:not([class*="hidden"])',
-                '[class*="conversation-title"]',
-                '[data-testid*="conversation-title"]',
-                '[aria-label*="conversation"]'
-            ],
-            uiElements: 'button, svg, [class*="regenerate"], [class*="more"], [data-testid*="copy"], [aria-label*="Copy"], [aria-label*="copy"]',
-            codeBlocks: 'pre',
-            media: 'img, canvas, video, audio'
-        },
-        patterns: {
-            geminiIndicators: /^(i understand|i can help|here's|i'll|let me|i'd be happy|certainly|of course|absolutely)/i,
-            userIndicators: /^(can you|please help|how do i|i need|i want|help me|could you|explain|what is)/i,
-            genericTitles: /^(gemini|new chat|untitled|chat|bard)$/i
-        },
-        limits: {
-            minMessageLength: 30,
-            maxMessageLength: 100000,
-            minWords: 5,
-            contentHashLength: 100
+    (function initChatExporterEngine(root, factory) {
+        const engine = factory();
+
+        if (root) {
+            root.ChatExporterEngine = engine;
         }
-    };
 
-    // Utility functions
-    const utils = {
-        formatDate: (date = new Date()) => date.toISOString().split('T')[0],
-        
-        cleanMarkdown: (text) => text
-            .replace(/\n{3,}/g, '\n\n')
-            .replace(/&lt;/g, '<')
-            .replace(/&gt;/g, '>')
-            .replace(/&amp;/g, '&'),
-        
-        createContentHash: (content) => 
-            content.substring(0, CONFIG.limits.contentHashLength)
-                   .replace(/\s+/g, ' ')
-                   .trim(),
-        
-        isValidMessageLength: (text) => {
-            const { minMessageLength, maxMessageLength, minWords } = CONFIG.limits;
-            return text.length >= minMessageLength && 
-                   text.length <= maxMessageLength && 
-                   text.split(' ').length >= minWords;
-        },
-
-        logStep: (message, data) => console.log(`[Gemini Exporter] ${message}`, data || ''),
-
-        getText: (element) => (element?.innerText ?? element?.textContent ?? '').trim(),
-        
-        showError: (message, details) => {
-            console.error(`[Gemini Exporter] ${message}`, details);
-            alert(`Export failed: ${message}`);
+        if (typeof module !== 'undefined' && module.exports) {
+            module.exports = engine;
         }
-    };
+    })(typeof globalThis !== 'undefined' ? globalThis : this, function buildChatExporterEngine() {
+        'use strict';
 
-    // Message processing functions
-    const messageProcessor = {
-        processContent: (element) => {
+        const ENGINE_VERSION = '0.7.0-live-engine';
+        const MARKER_PREFIX = '__CHAT_EXPORTER_BLOCK_';
+
+        const PROVIDERS = {
+            chatgpt: {
+                id: 'chatgpt',
+                assistantName: 'ChatGPT',
+                sourceLabel: 'chatgpt.com',
+                defaultTitle: 'Conversation with ChatGPT',
+                genericTitlePattern: /^(chatgpt|new chat|untitled|chat)$/i,
+                messageSelectors: [
+                    'div[data-message-author-role]',
+                    'article[data-testid*="conversation-turn"]',
+                    'div[data-testid="conversation-turn"]',
+                    '.group\\/conversation-turn',
+                    '[data-testid*="message"], [data-message-id], [data-message-author]'
+                ],
+                contentSelectors: [
+                    '.markdown, .prose, [class*="markdown"], [class*="prose"]',
+                    '[data-message-content], [data-testid*="content"]',
+                    '.whitespace-pre-wrap, [class*="whitespace"]'
+                ],
+                titleSelectors: [
+                    'h1:not([class*="hidden"])',
+                    '[class*="conversation-title"]',
+                    '[data-testid*="conversation-title"]'
+                ]
+            },
+            gemini: {
+                id: 'gemini',
+                assistantName: 'Gemini',
+                sourceLabel: 'gemini.google.com',
+                defaultTitle: 'Conversation with Gemini',
+                genericTitlePattern: /^(gemini|new chat|untitled|chat|bard)$/i,
+                messageSelectors: [
+                    'user-query, model-response',
+                    '[data-test-id="conversation-turn"]',
+                    '[data-testid="conversation-turn"]',
+                    '[data-message-author-role]',
+                    '[class*="conversation-turn"]',
+                    '[role="listitem"]'
+                ],
+                contentSelectors: [
+                    'message-content',
+                    '.query-text',
+                    '.response-container',
+                    '.markdown, .prose, [class*="markdown"], [class*="prose"]'
+                ],
+                titleSelectors: [
+                    'h1:not([class*="hidden"])',
+                    '[class*="conversation-title"]',
+                    '[data-testid*="conversation-title"]',
+                    '[aria-label*="conversation"]'
+                ]
+            }
+        };
+
+        function resolveDocument(doc) {
+            if (doc) return doc;
+            if (typeof document !== 'undefined') return document;
+            throw new Error('ChatExporterEngine requires a document.');
+        }
+
+        function getWindow(doc) {
+            return doc.defaultView || (typeof window !== 'undefined' ? window : null);
+        }
+
+        function formatDate(date = new Date()) {
+            return date.toISOString().split('T')[0];
+        }
+
+        function sanitizeHtml(value) {
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
+        function normalizeWhitespace(value) {
+            return String(value ?? '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+        }
+
+        function getClassName(element) {
+            const className = element?.className;
+            if (!className) return '';
+            if (typeof className === 'string') return className;
+            return className.baseVal || '';
+        }
+
+        function queryAll(root, selector) {
+            if (!root || !selector) return [];
+
+            try {
+                return Array.from(root.querySelectorAll(selector));
+            } catch (error) {
+                console.warn('[Chat Exporter] Selector failed:', selector, error);
+                return [];
+            }
+        }
+
+        function matches(element, selector) {
+            if (!element || !selector || typeof element.matches !== 'function') return false;
+
+            try {
+                return element.matches(selector);
+            } catch (error) {
+                return false;
+            }
+        }
+
+        function getText(element) {
+            if (!element) return '';
+            const innerText = typeof element.innerText === 'string' ? element.innerText : '';
+            return (innerText || element.textContent || '').replace(/\u00a0/g, ' ').trim();
+        }
+
+        function collectTextWithBreaks(node) {
+            if (!node) return '';
+
+            if (node.nodeType === 3) {
+                return node.nodeValue || '';
+            }
+
+            if (node.nodeType !== 1) {
+                return '';
+            }
+
+            const tag = node.tagName.toLowerCase();
+            if (tag === 'br') return '\n';
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+
+            const before = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+            const after = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+            return before + Array.from(node.childNodes).map(collectTextWithBreaks).join('') + after;
+        }
+
+        function getCodeText(element) {
+            if (!element) return '';
+
+            if (typeof element.innerText === 'string' && element.innerText.trim()) {
+                return element.innerText.replace(/\u00a0/g, ' ').replace(/\n{3,}/g, '\n\n').trimEnd();
+            }
+
             const clone = element.cloneNode(true);
-            
-            // Remove UI elements
-            clone.querySelectorAll(CONFIG.selectors.uiElements)
-                 .forEach(el => el.remove());
-            
-            messageProcessor.processCodeBlocks(clone);
-            messageProcessor.processMath(clone);
-            messageProcessor.processMedia(clone);
-            messageProcessor.processLinks(clone);
-            messageProcessor.processTables(clone);
-            
-            return utils.cleanMarkdown(utils.getText(clone));
-        },
+            queryAll(clone, 'br').forEach(br => br.replaceWith(clone.ownerDocument.createTextNode('\n')));
+            return collectTextWithBreaks(clone).replace(/\n{3,}/g, '\n\n').trimEnd();
+        }
 
-        processCodeBlocks: (clone) => {
-            clone.querySelectorAll(CONFIG.selectors.codeBlocks).forEach(pre => {
-                const { lang, code } = messageProcessor.extractCodeBlock(pre);
-                const codeBlock = document.createTextNode(`\n\n\`\`\`${lang}\n${code}\n\`\`\`\n`);
-                pre.parentNode.replaceChild(codeBlock, pre);
-            });
-        },
+        function normalizeCodeText(value) {
+            return String(value ?? '')
+                .replace(/\r\n?/g, '\n')
+                .replace(/^\n+/, '')
+                .replace(/\n+$/, '');
+        }
 
-        extractCodeBlock: (pre) => {
-            const codeEl = pre.querySelector('code');
-            const langMatch = codeEl?.className?.match(/language-([a-zA-Z0-9_-]+)/);
-            let lang = langMatch ? langMatch[1] : '';
+        function createTextNode(reference, text) {
+            return reference.ownerDocument.createTextNode(text);
+        }
 
-            if (!lang) {
-                const header = pre.querySelector('[class*="sticky"], [class*="code-header"], [data-test-id*="code"], [data-testid*="code"]');
-                const headerText = utils.getText(header).replace(/\b(copy|code|download)\b/gi, '').trim();
-                if (headerText && headerText.length < 30 && !headerText.includes('\n')) {
-                    lang = headerText.toLowerCase();
+        function addReplacement(replacements, html) {
+            const marker = `${MARKER_PREFIX}${replacements.length}__`;
+            replacements.push({ marker, html });
+            return marker;
+        }
+
+        function restoreReplacements(value, replacements) {
+            return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), value);
+        }
+
+        function cleanMarkdown(markdown) {
+            return String(markdown ?? '')
+                .split(/(```[\s\S]*?```)/g)
+                .map(part => part.startsWith('```')
+                    ? part
+                    : part
+                        .replace(/[ \t]+\n/g, '\n')
+                        .replace(/\n[ \t]+/g, '\n')
+                        .replace(/\n{3,}/g, '\n\n')
+                        .replace(/&lt;/g, '<')
+                        .replace(/&gt;/g, '>')
+                        .replace(/&amp;/g, '&'))
+                .join('')
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+        }
+
+        function escapeMarkdownLinkText(value) {
+            return String(value ?? '')
+                .replace(/\\/g, '\\\\')
+                .replace(/([\[\]])/g, '\\$1');
+        }
+
+        function escapeMarkdownUrl(value) {
+            return String(value ?? '')
+                .replace(/\\/g, '%5C')
+                .replace(/\)/g, '%29');
+        }
+
+        function isUnsafeHref(href) {
+            const lower = String(href || '').trim().toLowerCase();
+            return !lower ||
+                lower.startsWith('javascript:') ||
+                lower.startsWith('data:') ||
+                lower.startsWith('vbscript:') ||
+                lower.startsWith('#');
+        }
+
+        function topLevelElements(elements) {
+            return elements.filter(element => !elements.some(other => other !== element && other.contains(element)));
+        }
+
+        function removeUiElements(clone) {
+            const uiSelector = [
+                'button',
+                'svg',
+                'style',
+                'script',
+                'textarea',
+                'input',
+                '[contenteditable="true"]',
+                '[class*="regenerate"]',
+                '[class*="copy-button"]',
+                '[data-testid*="copy"]',
+                '[data-test-id*="copy"]',
+                '[aria-label*="Copy"]',
+                '[aria-label*="copy"]',
+                '[aria-label*="More"]',
+                '[aria-label*="more"]'
+            ].join(',');
+
+            queryAll(clone, uiSelector).forEach(element => element.remove());
+        }
+
+        function detectLanguage(block) {
+            const codeElement = matches(block, 'code') ? block : block.querySelector('code');
+            const sources = [
+                codeElement?.className,
+                block.getAttribute?.('data-language'),
+                block.getAttribute?.('language'),
+                block.getAttribute?.('lang'),
+                codeElement?.getAttribute?.('data-language'),
+                codeElement?.getAttribute?.('language'),
+                codeElement?.getAttribute?.('lang'),
+                block.getAttribute?.('aria-label')
+            ].filter(Boolean).map(String);
+
+            for (const source of sources) {
+                const languageMatch = source.match(/language-([a-zA-Z0-9_+#.-]+)/);
+                if (languageMatch) return languageMatch[1].toLowerCase();
+                if (/^[a-zA-Z0-9_+#.-]{1,24}$/.test(source) && !/^(code|copy|download)$/i.test(source)) {
+                    return source.toLowerCase();
                 }
-                header?.remove();
             }
 
-            const cmContent = pre.querySelector('.cm-content');
+            const header = block.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code"], [data-test-id*="code"], .code-language, .code-lang, [slot="header"]');
+            const headerText = normalizeWhitespace(getText(header)).replace(/\b(copy|code|download)\b/gi, '').trim();
+            if (headerText && headerText.length < 32 && !headerText.includes('\n')) {
+                return headerText.toLowerCase();
+            }
+
+            return '';
+        }
+
+        function extractCodeBlock(block) {
+            const clone = block.cloneNode(true);
+            const language = detectLanguage(clone);
+
+            queryAll(clone, 'button, svg, [aria-label*="Copy"], [aria-label*="copy"], [class*="sticky"], [class*="code-header"], [data-testid*="copy"], [data-test-id*="copy"], [slot="header"]').forEach(element => element.remove());
+
+            const cmContent = clone.querySelector('.cm-content');
             if (cmContent) {
-                const cmLines = cmContent.querySelectorAll('.cm-line');
+                const cmLines = queryAll(cmContent, '.cm-line');
                 if (cmLines.length > 0) {
-                    return { lang, code: Array.from(cmLines).map(line => line.textContent).join('\n').trim() };
+                    return {
+                        lang: language,
+                        code: normalizeCodeText(cmLines.map(line => line.textContent || '').join('\n'))
+                    };
                 }
 
-                cmContent.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
-                return { lang, code: cmContent.textContent.trim() };
+                return {
+                    lang: language,
+                    code: normalizeCodeText(getCodeText(cmContent))
+                };
             }
 
-            return { lang, code: utils.getText(codeEl || pre) };
-        },
+            const codeElement = matches(clone, 'code') ? clone : clone.querySelector('code');
+            return {
+                lang: language,
+                code: normalizeCodeText(getCodeText(codeElement || clone))
+            };
+        }
 
-        processMath: (clone) => {
+        function formatCodeBlock(block, format, replacements) {
+            const { lang, code } = extractCodeBlock(block);
+
+            if (format === 'markdown') {
+                return `\n\n\`\`\`${lang}\n${code}\n\`\`\`\n\n`;
+            }
+
+            const langClass = lang ? ` class="language-${sanitizeHtml(lang)}"` : '';
+            if (format === 'pdf') {
+                const label = lang ? `<div class="code-language">${sanitizeHtml(lang)}</div>` : '';
+                return addReplacement(replacements, `<pre class="code-block">${label}<code>${sanitizeHtml(code)}</code></pre>`);
+            }
+
+            return addReplacement(replacements, `<pre><code${langClass}>${sanitizeHtml(code)}</code></pre>`);
+        }
+
+        function processCodeBlocks(clone, format, replacements) {
+            const blocks = topLevelElements(queryAll(clone, 'pre, code-block, [data-testid*="code-block"], [data-test-id*="code-block"]'));
+
+            blocks.forEach(block => {
+                const replacement = formatCodeBlock(block, format, replacements);
+                block.replaceWith(createTextNode(block, replacement));
+            });
+        }
+
+        function processMath(clone) {
             const processed = new Set();
 
-            clone.querySelectorAll('annotation[encoding*="tex"]').forEach(annotation => {
+            queryAll(clone, 'annotation').forEach(annotation => {
+                const encoding = (annotation.getAttribute('encoding') || '').toLowerCase();
+                if (!encoding.includes('tex') && !encoding.includes('latex')) return;
+
                 const tex = annotation.textContent.trim();
                 if (!tex) return;
 
                 const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
-                const mathRoot = displayRoot || annotation.closest('.katex, mjx-container, math');
+                const mathRoot = displayRoot || annotation.closest('.katex') || annotation.closest('mjx-container') || annotation.closest('math');
                 if (!mathRoot || processed.has(mathRoot)) return;
 
                 processed.add(mathRoot);
-                mathRoot.replaceWith(document.createTextNode(displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+                mathRoot.replaceWith(createTextNode(mathRoot, displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
             });
 
-            clone.querySelectorAll('script[type^="math/tex"]').forEach(script => {
+            queryAll(clone, 'script[type^="math/tex"]').forEach(script => {
                 const tex = script.textContent.trim();
                 if (!tex) return;
                 const isDisplay = /mode=display/.test(script.type);
-                script.replaceWith(document.createTextNode(isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+                script.replaceWith(createTextNode(script, isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
             });
-        },
+        }
 
-        processMedia: (clone) => {
-            clone.querySelectorAll(CONFIG.selectors.media).forEach(el => {
-                const tag = el.tagName.toLowerCase();
-                const alt = el.getAttribute('alt') || el.getAttribute('aria-label') || '';
+        function processMedia(clone, format, replacements) {
+            queryAll(clone, 'img, canvas, video, audio').forEach(element => {
+                const tag = element.tagName.toLowerCase();
+                const alt = normalizeWhitespace(element.getAttribute('alt') || element.getAttribute('aria-label') || element.getAttribute('title') || '');
                 const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                    tag === 'img' ? '[Image]' :
                     tag === 'canvas' ? '[Canvas or chart]' :
                     tag === 'video' ? '[Video]' :
                     tag === 'audio' ? '[Audio]' :
                     '[Media]';
-                el.parentNode.replaceChild(document.createTextNode(label), el);
+
+                const replacement = format === 'markdown'
+                    ? label
+                    : addReplacement(replacements, `<span class="media-placeholder">${sanitizeHtml(label)}</span>`);
+                element.replaceWith(createTextNode(element, replacement));
             });
-        },
+        }
 
-        processLinks: (clone) => {
-            clone.querySelectorAll('a[href]').forEach(link => {
-                if (link.closest('pre, code')) return;
+        function processLinks(clone, format, replacements) {
+            queryAll(clone, 'a[href]').forEach(link => {
+                if (link.closest('pre, code, code-block')) return;
 
-                const href = (link.href || '').trim();
-                const lowerHref = href.toLowerCase();
-                if (!href || lowerHref.startsWith('javascript:') || lowerHref.startsWith('data:') || lowerHref.startsWith('vbscript:') || href.startsWith('#')) return;
+                const href = String(link.href || link.getAttribute('href') || '').trim();
+                if (isUnsafeHref(href)) return;
 
-                const text = link.textContent.replace(/\s+/g, ' ').trim() || href;
-                const escapedText = text
-                    .replace(/\\/g, '\\\\')
-                    .replace(/([\[\]])/g, '\\$1');
-                const safeHref = href
-                    .replace(/\\/g, '%5C')
-                    .replace(/\)/g, '%29');
-                link.replaceWith(document.createTextNode(`[${escapedText}](${safeHref})`));
+                const text = normalizeWhitespace(link.textContent) || href;
+                const replacement = format === 'markdown'
+                    ? `[${escapeMarkdownLinkText(text)}](${escapeMarkdownUrl(href)})`
+                    : addReplacement(replacements, `<a href="${sanitizeHtml(href)}">${sanitizeHtml(text)}</a>`);
+
+                link.replaceWith(createTextNode(link, replacement));
             });
-        },
+        }
 
-        tableCellText: (cell) => utils.getText(cell).replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim() || ' ',
+        function tableCellText(cell) {
+            return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+        }
 
-        tableToMarkdown: (table) => {
-            const rows = Array.from(table.querySelectorAll('tr'))
+        function tableToMarkdown(table) {
+            const rows = queryAll(table, 'tr')
                 .map(row => Array.from(row.children)
                     .filter(cell => ['TH', 'TD'].includes(cell.tagName))
-                    .map(messageProcessor.tableCellText))
-                .filter(cells => cells.length > 0);
+                    .map(tableCellText))
+                .filter(row => row.length > 0);
 
-            if (rows.length === 0) return utils.getText(table);
+            if (rows.length === 0) return normalizeWhitespace(getText(table));
 
             const width = Math.max(...rows.map(row => row.length));
             const normalizedRows = rows.map(row => row.concat(Array(Math.max(0, width - row.length)).fill(' ')));
             const header = normalizedRows[0];
             const separator = header.map(() => '---');
             const body = normalizedRows.slice(1);
-            const lines = [
+
+            return [
                 `| ${header.join(' | ')} |`,
                 `| ${separator.join(' | ')} |`,
                 ...body.map(row => `| ${row.join(' | ')} |`)
-            ];
-
-            return `\n\n${lines.join('\n')}\n\n`;
-        },
-
-        processTables: (clone) => {
-            clone.querySelectorAll('table').forEach(table => {
-                table.replaceWith(document.createTextNode(messageProcessor.tableToMarkdown(table)));
-            });
-        },
-
-        identifySender: (messageElement, index, allMessages) => {
-            // Try different identification methods in order of reliability
-            const methods = [
-                () => messageProcessor.checkDataAttributes(messageElement),
-                () => messageProcessor.checkAvatars(messageElement),
-                () => messageProcessor.analyzeContent(messageElement),
-                () => messageProcessor.analyzeStructure(messageElement),
-                () => messageProcessor.checkClasses(messageElement),
-                () => messageProcessor.contextualAnalysis(messageElement, index, allMessages)
-            ];
-
-            for (const method of methods) {
-                const result = method();
-                if (result) return result;
-            }
-
-            // Final fallback
-            return index % 2 === 0 ? 'You' : 'Gemini';
-        },
-
-        checkDataAttributes: (element) => {
-            const role = element.getAttribute('data-message-author-role');
-            return role === 'user' ? 'You' : ['model', 'assistant'].includes(role) ? 'Gemini' : null;
-        },
-
-        checkAvatars: (element) => {
-            const avatars = element.querySelectorAll('img');
-            for (const avatar of avatars) {
-                const attrs = [avatar.alt, avatar.src, avatar.className]
-                    .filter(Boolean)
-                    .join(' ')
-                    .toLowerCase();
-                
-                if (attrs.includes('user')) return 'You';
-                if (attrs.match(/gemini|assistant|bard/)) return 'Gemini';
-            }
-            return null;
-        },
-
-        analyzeContent: (element) => {
-            const textStart = element.textContent.toLowerCase().substring(0, 200);
-            if (CONFIG.patterns.geminiIndicators.test(textStart)) return 'Gemini';
-            if (CONFIG.patterns.userIndicators.test(textStart)) return 'You';
-            return null;
-        },
-
-        analyzeStructure: (element) => {
-            const hasCodeBlocks = element.querySelectorAll('pre, code').length > 0;
-            const hasLongText = element.textContent.length > 200;
-            const hasLists = element.querySelectorAll('ul, ol, li').length > 0;
-            
-            return (hasCodeBlocks && hasLongText && hasLists) ? 'Gemini' : null;
-        },
-
-        checkClasses: (element) => {
-            const classes = [element.className, element.parentElement?.className]
-                .filter(Boolean)
-                .join(' ')
-                .toLowerCase();
-            
-            if (classes.match(/model-response|assistant/)) return 'Gemini';
-            if (classes.includes('user')) return 'You';
-            return null;
-        },
-
-        contextualAnalysis: (element, index, allMessages) => {
-            if (index === 0 || !allMessages[index - 1]) return null;
-            
-            const prevLength = allMessages[index - 1].textContent.length;
-            const currentLength = element.textContent.length;
-            
-            if (prevLength < 100 && currentLength > 300) return 'Gemini';
-            if (prevLength > 300 && currentLength < 100) return 'You';
-            return null;
+            ].join('\n');
         }
-    };
 
-    // Message finder with improved error handling
-    const messageFinder = {
-        find: () => {
-            utils.logStep('Searching for messages...');
-            
-            // Try each selector until we find messages
-            for (const selector of CONFIG.selectors.messages) {
-                const messages = document.querySelectorAll(selector);
+        function tableToHtml(table) {
+            const rows = queryAll(table, 'tr')
+                .map(row => Array.from(row.children)
+                    .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                    .map(cell => ({
+                        tag: cell.tagName.toLowerCase(),
+                        text: normalizeWhitespace(getText(cell))
+                    })))
+                .filter(row => row.length > 0);
+
+            if (rows.length === 0) return sanitizeHtml(getText(table));
+
+            return `<table>${rows.map(row => {
+                const cells = row.map(cell => `<${cell.tag}>${sanitizeHtml(cell.text)}</${cell.tag}>`).join('');
+                return `<tr>${cells}</tr>`;
+            }).join('')}</table>`;
+        }
+
+        function processTables(clone, format, replacements) {
+            topLevelElements(queryAll(clone, 'table')).forEach(table => {
+                const replacement = format === 'markdown'
+                    ? `\n\n${tableToMarkdown(table)}\n\n`
+                    : addReplacement(replacements, tableToHtml(table));
+                table.replaceWith(createTextNode(table, replacement));
+            });
+        }
+
+        function cardSignal(element) {
+            const pieces = [
+                element.tagName,
+                getClassName(element),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id'),
+                element.getAttribute('aria-label'),
+                element.getAttribute('role')
+            ].filter(Boolean).join(' ').toLowerCase();
+
+            if (/\b(artifact|canvas-preview|generated-file|download-card|attachment|file-card)\b/.test(pieces)) {
+                return pieces.includes('artifact') || pieces.includes('canvas-preview') ? 'Artifact' : 'File';
+            }
+
+            if (/(^|[\s_-])(attachment|file)([\s_-]|$)/.test(pieces)) {
+                return 'File';
+            }
+
+            return '';
+        }
+
+        function cardLabel(element) {
+            const candidates = [
+                element.getAttribute('aria-label'),
+                element.getAttribute('title'),
+                element.getAttribute('download'),
+                element.getAttribute('data-filename'),
+                getText(element)
+            ].filter(Boolean).map(normalizeWhitespace);
+
+            const label = candidates.find(value => value && value.length <= 180) || '';
+            return label
+                .replace(/\b(open|download|preview|file|attachment|artifact)\b/gi, ' ')
+                .replace(/\s+/g, ' ')
+                .trim();
+        }
+
+        function processCards(clone, format, replacements) {
+            const cards = topLevelElements(Array.from(clone.querySelectorAll('*')).filter(element => {
+                const kind = cardSignal(element);
+                if (!kind) return false;
+                if (matches(element, '[data-message-author-role], user-query, model-response')) return false;
+                if (element.closest('pre, code, code-block, table')) return false;
+                if (element.querySelector('pre, code-block, table, user-query, model-response')) return false;
+
+                const text = normalizeWhitespace(getText(element));
+                const label = cardLabel(element);
+                return Boolean(label || text) && text.length <= 240;
+            }));
+
+            cards.forEach(card => {
+                const kind = cardSignal(card);
+                const label = cardLabel(card);
+                const text = label ? `[${kind}: ${label}]` : `[${kind}]`;
+                const replacement = format === 'markdown'
+                    ? text
+                    : addReplacement(replacements, `<span class="card-placeholder">${sanitizeHtml(text)}</span>`);
+                card.replaceWith(createTextNode(card, replacement));
+            });
+        }
+
+        function serializeMarkdownChildren(element, context = {}) {
+            return Array.from(element.childNodes).map((node, index) => serializeMarkdownNode(node, {
+                ...context,
+                index
+            })).join('');
+        }
+
+        function serializeMarkdownNode(node, context = {}) {
+            if (node.nodeType === 3) {
+                const value = node.nodeValue || '';
+                if (value.includes('```') || value.includes('| ---') || value.includes(MARKER_PREFIX) || value.match(/^\s*\[[^\]]+\]/)) {
+                    return value;
+                }
+                return value.replace(/[ \t\r\n]+/g, ' ');
+            }
+
+            if (node.nodeType !== 1) return '';
+
+            const tag = node.tagName.toLowerCase();
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+            if (tag === 'br') return '\n';
+
+            if (/^h[1-6]$/.test(tag)) {
+                const level = Number(tag.slice(1));
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${'#'.repeat(level)} ${content}\n\n` : '';
+            }
+
+            if (tag === 'p') {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${content}\n\n` : '';
+            }
+
+            if (tag === 'blockquote') {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `\n\n${content.split('\n').map(line => `> ${line.trim()}`).join('\n')}\n\n` : '';
+            }
+
+            if (tag === 'ul' || tag === 'ol') {
+                const children = Array.from(node.children).filter(child => child.tagName && child.tagName.toLowerCase() === 'li');
+                return `\n${children.map((child, index) => serializeMarkdownNode(child, {
+                    ...context,
+                    listType: tag,
+                    index,
+                    depth: (context.depth || 0)
+                })).join('')}\n`;
+            }
+
+            if (tag === 'li') {
+                const depth = context.depth || 0;
+                const marker = context.listType === 'ol' ? `${(context.index || 0) + 1}. ` : '- ';
+                const indent = '  '.repeat(depth);
+                const content = serializeMarkdownChildren(node, {
+                    ...context,
+                    depth: depth + 1
+                }).trim();
+                return content ? `${indent}${marker}${content.replace(/\n+/g, `\n${indent}  `)}\n` : '';
+            }
+
+            if (['strong', 'b'].includes(tag)) {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `**${content}**` : '';
+            }
+
+            if (['em', 'i'].includes(tag)) {
+                const content = serializeMarkdownChildren(node, context).trim();
+                return content ? `*${content}*` : '';
+            }
+
+            if (tag === 'code') {
+                const content = getCodeText(node).replace(/`/g, '\\`').trim();
+                return content ? `\`${content}\`` : '';
+            }
+
+            const content = serializeMarkdownChildren(node, context);
+            if (['div', 'section', 'article', 'main', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+                return content;
+            }
+
+            return content;
+        }
+
+        function serializeHtmlChildren(element, replacements) {
+            return Array.from(element.childNodes).map(node => serializeHtmlNode(node, replacements)).join('');
+        }
+
+        function serializeHtmlNode(node, replacements) {
+            if (node.nodeType === 3) {
+                return sanitizeHtml(node.nodeValue || '');
+            }
+
+            if (node.nodeType !== 1) return '';
+
+            const tag = node.tagName.toLowerCase();
+            if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+            if (tag === 'br') return '<br>';
+
+            const content = serializeHtmlChildren(node, replacements);
+            const blockTags = new Set(['p', 'ul', 'ol', 'li', 'blockquote', 'strong', 'b', 'em', 'i']);
+
+            if (/^h[1-6]$/.test(tag)) {
+                return `<${tag}>${content}</${tag}>`;
+            }
+
+            if (blockTags.has(tag)) {
+                const safeTag = tag === 'b' ? 'strong' : tag === 'i' ? 'em' : tag;
+                return `<${safeTag}>${content}</${safeTag}>`;
+            }
+
+            if (tag === 'code') {
+                return `<code>${sanitizeHtml(getCodeText(node).trim())}</code>`;
+            }
+
+            if (['div', 'section', 'article', 'main', 'span', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+                return content;
+            }
+
+            return content;
+        }
+
+        function serializeMessageContent(element, format) {
+            const clone = element.cloneNode(true);
+            const replacements = [];
+
+            removeUiElements(clone);
+            processCards(clone, format, replacements);
+            processCodeBlocks(clone, format, replacements);
+            processMath(clone);
+            processMedia(clone, format, replacements);
+            processLinks(clone, format, replacements);
+            processTables(clone, format, replacements);
+
+            if (format === 'markdown') {
+                return cleanMarkdown(serializeMarkdownChildren(clone));
+            }
+
+            const html = serializeHtmlChildren(clone, replacements)
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+            return restoreReplacements(html, replacements);
+        }
+
+        function detectProvider(doc) {
+            const url = doc.defaultView?.location?.href || '';
+            if (/gemini\.google\.com/i.test(url) || doc.querySelector('user-query, model-response')) return 'gemini';
+            return 'chatgpt';
+        }
+
+        function providerFor(providerName, doc) {
+            const id = providerName || detectProvider(doc);
+            return PROVIDERS[id] || PROVIDERS.chatgpt;
+        }
+
+        function meaningfulScore(element) {
+            const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+            return normalizeWhitespace(element.textContent).length + richCount * 200;
+        }
+
+        function isValidMessage(element) {
+            const text = normalizeWhitespace(element.textContent);
+            const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+
+            if (text.length < 5 && richCount === 0) return false;
+            if (text.length > 200000) return false;
+            if (matches(element, 'nav, aside, header, footer, form, menu')) return false;
+            if (element.querySelector('textarea, input[type="text"], [contenteditable="true"]') && !element.hasAttribute('data-message-author-role')) return false;
+            if (getClassName(element).match(/\b(typing|loading|spinner)\b/i)) return false;
+
+            return true;
+        }
+
+        function findMessages(doc, provider) {
+            for (const selector of provider.messageSelectors) {
+                const messages = topLevelElements(queryAll(doc, selector)).filter(isValidMessage);
                 if (messages.length > 0) {
-                    utils.logStep(`Found ${messages.length} messages with selector: ${selector}`);
-                    return messageFinder.validateMessages(Array.from(messages));
+                    console.log(`[Chat Exporter] ${provider.id}: using selector "${selector}" (${messages.length} messages)`);
+                    return messages;
                 }
             }
 
-            // Fallback approach
-            return messageFinder.fallbackSearch();
-        },
-
-        validateMessages: (messages) => {
-            return messages.filter(msg => {
-                const text = msg.textContent.trim();
-                
-                if (!utils.isValidMessageLength(text)) return false;
-                if (msg.querySelector('input[type="text"], textarea')) return false;
-                if (msg.classList.contains('typing') || msg.classList.contains('loading')) return false;
-                
-                return true;
-            });
-        },
-
-        fallbackSearch: () => {
-            utils.logStep('Trying fallback search...');
-            const container = document.querySelector(
-                '[role="main"], main, .conversation, [class*="conversation"], [class*="chat"]'
-            );
-            
+            const container = doc.querySelector('[role="main"], main, [class*="conversation"], [class*="chat"]');
             if (!container) return [];
-            
-            const messages = container.querySelectorAll(':scope > div, :scope > article');
-            utils.logStep(`Fallback found ${messages.length} potential messages`);
-            
-            return messageFinder.validateMessages(Array.from(messages));
-        },
 
-        consolidateMessages: (messages) => {
-            const consolidated = [];
-            const usedElements = new Set();
-
-            messages.forEach(msg => {
-                if (usedElements.has(msg)) return;
-                
-                const isNested = messages.some(other => 
-                    other !== msg && other.contains(msg) && !usedElements.has(other)
-                );
-                
-                if (!isNested) {
-                    consolidated.push(msg);
-                    usedElements.add(msg);
-                }
-            });
-
-            return consolidated;
+            return topLevelElements(queryAll(container, ':scope > article, :scope > section, :scope > div')).filter(isValidMessage);
         }
-    };
 
-    // Export functionality
-    const exporter = {
-        extractTitle: () => {
-            for (const selector of CONFIG.selectors.title) {
-                const element = document.querySelector(selector);
-                if (element?.textContent?.trim()) {
-                    const title = element.textContent.trim();
-                    if (!CONFIG.patterns.genericTitles.test(title)) {
-                        return title;
-                    }
-                }
-            }
-            return 'Conversation with Gemini';
-        },
+        function selectContentRoot(messageElement, provider) {
+            const candidates = [messageElement];
 
-        processMessages: (messages) => {
-            const processed = [];
-            const seenContent = new Set();
-
-            messages.forEach((messageElement, index) => {
-                try {
-                    const content = messageProcessor.processContent(messageElement);
-                    
-                    if (!content || content.trim().length < CONFIG.limits.minMessageLength) {
-                        utils.logStep(`Skipping message ${index}: too short`);
-                        return;
-                    }
-
-                    const contentHash = utils.createContentHash(content);
-                    if (seenContent.has(contentHash)) {
-                        utils.logStep(`Skipping message ${index}: duplicate`);
-                        return;
-                    }
-                    seenContent.add(contentHash);
-
-                    const sender = messageProcessor.identifySender(messageElement, index, messages);
-                    processed.push({ sender, content, originalIndex: index });
-                    
-                } catch (error) {
-                    utils.logStep(`Error processing message ${index}:`, error.message);
-                }
+            provider.contentSelectors.forEach(selector => {
+                if (matches(messageElement, selector)) candidates.push(messageElement);
+                candidates.push(...queryAll(messageElement, selector));
             });
 
-            return exporter.fixSenderSequence(processed);
-        },
+            return candidates
+                .filter(Boolean)
+                .sort((a, b) => meaningfulScore(b) - meaningfulScore(a))[0] || messageElement;
+        }
 
-        fixSenderSequence: (messages) => {
-            for (let i = 1; i < messages.length; i++) {
-                const current = messages[i];
-                const previous = messages[i - 1];
-                
-                if (current.sender === previous.sender) {
-                    const currentLength = current.content.length;
-                    const previousLength = previous.content.length;
-                    
-                    if (currentLength > previousLength * 2 && currentLength > 500) {
-                        current.sender = 'Gemini';
-                    } else if (previousLength > currentLength * 2 && previousLength > 500) {
-                        previous.sender = 'Gemini';
-                        current.sender = 'You';
-                    } else {
-                        current.sender = current.sender === 'You' ? 'Gemini' : 'You';
-                    }
-                    
-                    utils.logStep(`Fixed consecutive messages at positions ${i-1} and ${i}`);
+        function identifySender(element, index, provider) {
+            const tag = element.tagName.toLowerCase();
+            if (tag === 'user-query') return { sender: 'You', reliable: true };
+            if (tag === 'model-response') return { sender: provider.assistantName, reliable: true };
+
+            const role = element.getAttribute('data-message-author-role') || element.getAttribute('data-author') || element.getAttribute('data-sender');
+            if (role) {
+                const normalizedRole = role.toLowerCase();
+                if (normalizedRole === 'user') return { sender: 'You', reliable: true };
+                if (['assistant', 'model', 'bot', 'chatgpt', 'gemini'].includes(normalizedRole)) {
+                    return { sender: provider.assistantName, reliable: true };
                 }
             }
-            return messages;
-        },
 
-        generateMarkdown: (messages) => {
-            const title = exporter.extractTitle();
-            const date = utils.formatDate();
-            const url = window.location.href;
+            const classAndAttrs = [
+                getClassName(element),
+                element.getAttribute('aria-label'),
+                element.getAttribute('data-testid'),
+                element.getAttribute('data-test-id')
+            ].filter(Boolean).join(' ').toLowerCase();
 
+            if (classAndAttrs.match(/\b(user|human|query)\b/)) return { sender: 'You', reliable: false };
+            if (classAndAttrs.match(/\b(assistant|model|response|chatgpt|gemini|bard)\b/)) return { sender: provider.assistantName, reliable: false };
+
+            const textStart = normalizeWhitespace(element.textContent).slice(0, 220).toLowerCase();
+            if (/^(i understand|i can help|here's|i'll|let me|i'd be happy|certainly|of course|absolutely)/.test(textStart)) {
+                return { sender: provider.assistantName, reliable: false };
+            }
+
+            if (/^(can you|please help|how do i|i need|i want|help me|could you|explain|what is)/.test(textStart)) {
+                return { sender: 'You', reliable: false };
+            }
+
+            return { sender: index % 2 === 0 ? 'You' : provider.assistantName, reliable: false };
+        }
+
+        function contentHash(content) {
+            return normalizeWhitespace(String(content || '').replace(/<[^>]+>/g, ' ')).slice(0, 160);
+        }
+
+        function extractConversation(options = {}) {
+            const doc = resolveDocument(options.document);
+            const provider = providerFor(options.provider, doc);
+            const format = options.format || 'markdown';
+            const rawMessages = findMessages(doc, provider);
+            const seen = new Set();
+            const messages = [];
+
+            rawMessages.forEach((messageElement, index) => {
+                const contentRoot = selectContentRoot(messageElement, provider);
+                const content = serializeMessageContent(contentRoot, format);
+                const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
+
+                if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+
+                const hash = contentHash(content);
+                if (seen.has(hash)) return;
+                seen.add(hash);
+
+                const sender = identifySender(messageElement, index, provider);
+                messages.push({
+                    sender: sender.sender,
+                    senderType: sender.sender === 'You' ? 'user' : 'assistant',
+                    reliableSender: sender.reliable,
+                    content,
+                    index
+                });
+            });
+
+            return {
+                version: ENGINE_VERSION,
+                provider: provider.id,
+                providerLabel: provider.assistantName,
+                sourceLabel: provider.sourceLabel,
+                title: extractConversationTitle(doc, provider),
+                sourceUrl: doc.defaultView?.location?.href || '',
+                date: formatDate(options.date || new Date()),
+                messages
+            };
+        }
+
+        function extractConversationTitle(doc, provider) {
+            for (const selector of provider.titleSelectors) {
+                const element = doc.querySelector(selector);
+                const title = normalizeWhitespace(element?.textContent);
+                if (title && !provider.genericTitlePattern.test(title)) return title;
+            }
+
+            const docTitle = normalizeWhitespace(doc.title);
+            if (docTitle && !provider.genericTitlePattern.test(docTitle)) return docTitle;
+
+            return provider.defaultTitle;
+        }
+
+        function renderMarkdown(conversation) {
             const lines = [
-                `# ${title}\n`,
-                `**Date:** ${date}`,
-                `**Source:** [gemini.google.com](${url})\n`,
-                `---\n`
+                `# ${conversation.title}\n`,
+                `**Date:** ${conversation.date}`,
+                `**Source:** [${conversation.sourceLabel}](${conversation.sourceUrl})\n`,
+                '---\n'
             ];
 
-            messages.forEach(({ sender, content }) => {
-                lines.push(`### **${sender}**\n`, content, '\n---\n');
+            conversation.messages.forEach(message => {
+                lines.push(`### **${message.sender}**\n`, message.content, '\n---\n');
             });
 
-            return lines.join('\n');
-        },
+            return `${lines.join('\n').trim()}\n`;
+        }
 
-        downloadFile: (content, filename) => {
-            try {
-                const blob = new Blob([content], { type: 'text/markdown' });
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                
-                a.href = url;
-                a.download = filename;
-                document.body.appendChild(a);
-                a.click();
-                document.body.removeChild(a);
-                URL.revokeObjectURL(url);
-                
-                return true;
-            } catch (error) {
-                utils.showError('Failed to download file', error);
-                return false;
+        function renderHtmlDocument(conversation, options = {}) {
+            const isPdf = options.format === 'pdf';
+            const source = sanitizeHtml(conversation.sourceUrl);
+            const title = sanitizeHtml(conversation.title);
+            const messages = conversation.messages.map(message => {
+                const senderClass = message.senderType === 'user' ? 'user' : 'assistant';
+                return `
+            <div class="message ${senderClass}">
+                <div class="sender">${sanitizeHtml(message.sender)}</div>
+                <div class="content">${message.content}</div>
+            </div>`;
+            }).join('');
+
+            const pdfInstructions = isPdf ? `
+        <div class="instructions no-print">
+            <h3>Convert to PDF</h3>
+            <ol>
+                <li>Press Ctrl+P on Windows/Linux or Cmd+P on Mac.</li>
+                <li>Set Destination to Save as PDF.</li>
+                <li>Choose your preferred page size.</li>
+                <li>Click Save.</li>
+            </ol>
+            <p><em>This instruction box will not appear in the PDF.</em></p>
+        </div>` : '';
+
+            return `<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <title>${title} - ${conversation.date}</title>
+        <style>
+            @media print {
+                body { margin: 0; }
+                .no-print { display: none; }
+                .message { page-break-inside: avoid; }
             }
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+                max-width: 840px;
+                margin: auto;
+                padding: 2rem;
+                background: #fff;
+                color: #333;
+                line-height: 1.6;
+            }
+            .header {
+                text-align: center;
+                margin-bottom: 2rem;
+                padding-bottom: 1rem;
+                border-bottom: 2px solid #eee;
+            }
+            .metadata {
+                color: #666;
+                font-size: 0.9rem;
+            }
+            .message {
+                margin-bottom: 1.5rem;
+                padding: 1rem;
+                border-radius: 8px;
+                background: #f8f9fa;
+            }
+            .message.user {
+                background: #eaf4ff;
+            }
+            .sender {
+                font-weight: 700;
+                color: #2c3e50;
+                margin-bottom: 0.5rem;
+            }
+            .content {
+                white-space: pre-wrap;
+                overflow-wrap: anywhere;
+            }
+            pre {
+                background: #f4f4f4;
+                padding: 1rem;
+                border-radius: 4px;
+                overflow-x: auto;
+                border-left: 4px solid #007acc;
+            }
+            .code-block {
+                background: #282c34;
+                color: #abb2bf;
+                border-left: 0;
+            }
+            .code-block code {
+                white-space: pre;
+            }
+            .code-language {
+                color: #d7dae0;
+                font-size: 12px;
+                margin-bottom: 8px;
+                text-transform: uppercase;
+            }
+            code {
+                font-family: Consolas, Monaco, "Courier New", monospace;
+                font-size: 0.92rem;
+            }
+            table {
+                width: 100%;
+                border-collapse: collapse;
+                margin: 1rem 0;
+            }
+            th, td {
+                border: 1px solid #d9dde3;
+                padding: 0.5rem;
+                text-align: left;
+                vertical-align: top;
+            }
+            th {
+                background: #eef2f7;
+            }
+            .instructions {
+                background: #fff8dc;
+                border: 1px solid #e3c565;
+                border-radius: 8px;
+                padding: 1rem;
+                margin-bottom: 1.5rem;
+            }
+        </style>
+    </head>
+    <body>
+        ${pdfInstructions}
+        <div class="header">
+            <h1>${title}</h1>
+            <div class="metadata">
+                <div><strong>Date:</strong> ${sanitizeHtml(conversation.date)}</div>
+                <div><strong>Source:</strong> <a href="${source}">${sanitizeHtml(conversation.sourceLabel)}</a></div>
+                <div><strong>Messages:</strong> ${conversation.messages.length}</div>
+            </div>
+        </div>
+        <div class="conversation">${messages}
+        </div>
+    </body>
+    </html>`;
         }
-    };
 
-    // Main execution with comprehensive error handling
-    try {
-        utils.logStep('Starting Gemini conversation export...');
-        
-        const rawMessages = messageFinder.find();
-        if (rawMessages.length === 0) {
-            utils.showError('No messages found. The page structure may have changed.');
-            return;
+        function render(conversation, format) {
+            if (format === 'markdown') return renderMarkdown(conversation);
+            if (format === 'pdf') return renderHtmlDocument(conversation, { format: 'pdf' });
+            if (format === 'html') return renderHtmlDocument(conversation, { format: 'html' });
+            throw new Error(`Unsupported export format: ${format}`);
         }
 
-        const consolidatedMessages = messageFinder.consolidateMessages(rawMessages);
-        utils.logStep(`Consolidated ${rawMessages.length} raw messages into ${consolidatedMessages.length} valid messages`);
+        function filenameFor(conversation, format, doc) {
+            const safeTitle = normalizeWhitespace(doc.title || conversation.title)
+                .replace(/[<>:"/\\|?*]/g, '')
+                .slice(0, 120);
 
-        const processedMessages = exporter.processMessages(consolidatedMessages);
-        if (processedMessages.length === 0) {
-            utils.showError('No valid messages could be processed.');
-            return;
+            if (format === 'markdown') {
+                return safeTitle ? `${safeTitle} (${conversation.date}).md` : `${conversation.providerLabel}_Conversation_${conversation.date}.md`;
+            }
+
+            if (format === 'pdf') {
+                return safeTitle ? `${safeTitle} (${conversation.date}) - PrintToPDF.html` : `${conversation.providerLabel}_Conversation_${conversation.date}_PrintToPDF.html`;
+            }
+
+            return safeTitle ? `${safeTitle} (${conversation.date}).html` : `${conversation.providerLabel}_Conversation_${conversation.date}.html`;
         }
 
-        const markdown = exporter.generateMarkdown(processedMessages);
-        const filename = `Gemini_Conversation_${utils.formatDate()}.md`;
-        
-        if (exporter.downloadFile(markdown, filename)) {
-            utils.logStep(`Export completed successfully: ${processedMessages.length} messages exported`);
-            console.log(`File downloaded: ${filename}`);
+        function mimeFor(format) {
+            return format === 'markdown' ? 'text/markdown' : 'text/html';
         }
 
-    } catch (error) {
-        utils.showError('Unexpected error during export', error);
-        console.error('[Gemini Exporter] Full error details:', error);
-    }
+        function downloadFile(doc, content, filename, mimeType) {
+            const win = getWindow(doc);
+            const BlobCtor = win?.Blob || Blob;
+            const urlApi = win?.URL || URL;
+            const blob = new BlobCtor([content], { type: mimeType });
+            const url = urlApi.createObjectURL(blob);
+            const anchor = doc.createElement('a');
+
+            anchor.href = url;
+            anchor.download = filename;
+            doc.body.appendChild(anchor);
+            anchor.click();
+            doc.body.removeChild(anchor);
+            urlApi.revokeObjectURL(url);
+        }
+
+        function exportConversation(options = {}) {
+            const doc = resolveDocument(options.document);
+            const format = options.format || 'markdown';
+            const conversation = extractConversation({
+                ...options,
+                document: doc,
+                format
+            });
+
+            if (conversation.messages.length === 0) {
+                const message = 'No messages found. The page structure may have changed.';
+                const win = getWindow(doc);
+                if (typeof win?.alert === 'function') win.alert(message);
+                console.warn(`[Chat Exporter] ${message}`);
+                return { conversation, content: '' };
+            }
+
+            const content = render(conversation, format);
+            const filename = options.filename || filenameFor(conversation, format, doc);
+
+            if (options.download !== false) {
+                downloadFile(doc, content, filename, mimeFor(format));
+                console.log(`[Chat Exporter] Exported ${conversation.messages.length} messages to ${filename}`);
+            }
+
+            return { conversation, content, filename };
+        }
+
+        return {
+            version: ENGINE_VERSION,
+            providers: PROVIDERS,
+            detectProvider,
+            extractConversation,
+            exportConversation,
+            serializers: {
+                markdown: renderMarkdown,
+                html: conversation => renderHtmlDocument(conversation, { format: 'html' }),
+                pdf: conversation => renderHtmlDocument(conversation, { format: 'pdf' })
+            },
+            internals: {
+                serializeMessageContent,
+                extractCodeBlock,
+                tableToMarkdown,
+                tableToHtml
+            }
+        };
+    });
+
+    globalThis.ChatExporterEngine.exportConversation({
+        provider: 'gemini',
+        format: 'markdown'
+    });
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt-chat-exporter-master",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-chat-exporter-master",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "ISC",
       "devDependencies": {
         "jsdom": "^29.1.1"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "chatgpt-chat-exporter-master",
-  "version": "0.6.0",
-  "description": "*Version: v0.6.0*",
+  "version": "0.7.0",
+  "description": "*Version: v0.7.0*",
   "main": "exporter-html.js",
   "scripts": {
-    "test": "node --test"
+    "build": "node scripts/build-exporters.js",
+    "test": "node scripts/build-exporters.js --check && node --test"
   },
   "repository": {
     "type": "git",

--- a/scripts/build-exporters.js
+++ b/scripts/build-exporters.js
@@ -1,0 +1,164 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const engineSource = fs.readFileSync(path.join(repoRoot, 'src', 'extraction-engine.js'), 'utf8').trim();
+const checkOnly = process.argv.includes('--check');
+
+const GENERATED_NOTICE = `// Generated from src/extraction-engine.js by scripts/build-exporters.js.
+// Edit the source engine or this build script, then run npm run build.
+
+`;
+
+function runner(provider, format) {
+    return `${GENERATED_NOTICE}(() => {
+    'use strict';
+
+${indent(engineSource, 4)}
+
+    globalThis.ChatExporterEngine.exportConversation({
+        provider: '${provider}',
+        format: '${format}'
+    });
+})();
+`;
+}
+
+function userscriptHeader(name, version, description) {
+    return `// ==UserScript==
+// @name         ${name}
+// @namespace    https://github.com/rashidazarang/chatgpt-chat-exporter
+// @version      ${version}
+// @description  ${description}
+// @author       rashidazarang
+// @match        https://chat.openai.com/*
+// @match        https://chatgpt.com/*
+// @match        https://chatgpt.com/c/*
+// @match        https://chat.com/*
+// @grant        none
+// @license      MIT
+// ==/UserScript==
+
+`;
+}
+
+function userscript(provider, format, buttonId, buttonText, right, color, hoverColor, name, description) {
+    return `${userscriptHeader(name, '0.7.0', description)}(() => {
+    'use strict';
+
+${indent(engineSource, 4)}
+
+    function runExport() {
+        globalThis.ChatExporterEngine.exportConversation({
+            provider: '${provider}',
+            format: '${format}'
+        });
+    }
+
+    function addExportButton() {
+        if (document.querySelector('#${buttonId}')) return;
+
+        const button = document.createElement('button');
+        button.id = '${buttonId}';
+        button.textContent = '${buttonText}';
+        button.style.cssText = [
+            'position: fixed',
+            'bottom: 20px',
+            'right: ${right}',
+            'padding: 10px 16px',
+            'background-color: ${color}',
+            'color: white',
+            'border: none',
+            'border-radius: 5px',
+            'cursor: pointer',
+            'z-index: 10000',
+            'font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+            'font-size: 14px',
+            'font-weight: 600',
+            'box-shadow: 0 2px 4px rgba(0,0,0,0.2)'
+        ].join(';');
+
+        button.addEventListener('click', runExport);
+        button.addEventListener('mouseenter', () => {
+            button.style.backgroundColor = '${hoverColor}';
+        });
+        button.addEventListener('mouseleave', () => {
+            button.style.backgroundColor = '${color}';
+        });
+
+        document.body.appendChild(button);
+    }
+
+    function installButton() {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => setTimeout(addExportButton, 1000), { once: true });
+        } else {
+            setTimeout(addExportButton, 1000);
+        }
+
+        const observer = new MutationObserver(() => {
+            if (!document.querySelector('#${buttonId}')) addExportButton();
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    installButton();
+})();
+`;
+}
+
+function indent(value, spaces) {
+    const prefix = ' '.repeat(spaces);
+    return value.split('\n').map(line => line ? `${prefix}${line}` : '').join('\n');
+}
+
+const outputs = new Map([
+    ['exporter-markdown.js', runner('chatgpt', 'markdown')],
+    ['exporter-html.js', runner('chatgpt', 'html')],
+    ['exporter-pdf.js', runner('chatgpt', 'pdf')],
+    ['gemini-exporter-markdown.js', runner('gemini', 'markdown')],
+    ['chatgpt-markdown-exporter.user.js', userscript(
+        'chatgpt',
+        'markdown',
+        'chatgpt-export-markdown-btn',
+        'Export Markdown',
+        '20px',
+        '#10a37f',
+        '#0d8f6e',
+        'ChatGPT Chat Exporter - Markdown',
+        'Export ChatGPT conversations to Markdown format'
+    )],
+    ['chatgpt-pdf-exporter.user.js', userscript(
+        'chatgpt',
+        'pdf',
+        'chatgpt-export-pdf-btn',
+        'Export PDF',
+        '170px',
+        '#3498db',
+        '#2c7fb8',
+        'ChatGPT Chat Exporter - PDF',
+        'Export ChatGPT conversations to PDF-ready HTML format'
+    )]
+]);
+
+let failed = false;
+
+for (const [relativePath, content] of outputs) {
+    const absolutePath = path.join(repoRoot, relativePath);
+
+    if (checkOnly) {
+        const current = fs.existsSync(absolutePath) ? fs.readFileSync(absolutePath, 'utf8') : null;
+        if (current !== content) {
+            console.error(`${relativePath} is not up to date. Run npm run build.`);
+            failed = true;
+        }
+        continue;
+    }
+
+    fs.writeFileSync(absolutePath, content);
+    console.log(`Wrote ${relativePath}`);
+}
+
+if (failed) {
+    process.exitCode = 1;
+}

--- a/src/extraction-engine.js
+++ b/src/extraction-engine.js
@@ -391,7 +391,9 @@
     }
 
     function tableCellText(cell) {
-        return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+        return normalizeWhitespace(getText(cell))
+            .replace(/\\/g, '\\\\')
+            .replace(/\|/g, '\\|') || ' ';
     }
 
     function tableToMarkdown(table) {
@@ -574,7 +576,10 @@
         }
 
         if (tag === 'code') {
-            const content = getCodeText(node).replace(/`/g, '\\`').trim();
+            const content = getCodeText(node)
+                .replace(/\\/g, '\\\\')
+                .replace(/`/g, '\\`')
+                .trim();
             return content ? `\`${content}\`` : '';
         }
 
@@ -756,7 +761,7 @@
             const content = serializeMessageContent(contentRoot, format);
             const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
 
-            if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+            if (!content || normalizeWhitespace(content).length < minLength) return;
 
             const hash = contentHash(content);
             if (seen.has(hash)) return;

--- a/src/extraction-engine.js
+++ b/src/extraction-engine.js
@@ -1,0 +1,1041 @@
+(function initChatExporterEngine(root, factory) {
+    const engine = factory();
+
+    if (root) {
+        root.ChatExporterEngine = engine;
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = engine;
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function buildChatExporterEngine() {
+    'use strict';
+
+    const ENGINE_VERSION = '0.7.0-live-engine';
+    const MARKER_PREFIX = '__CHAT_EXPORTER_BLOCK_';
+
+    const PROVIDERS = {
+        chatgpt: {
+            id: 'chatgpt',
+            assistantName: 'ChatGPT',
+            sourceLabel: 'chatgpt.com',
+            defaultTitle: 'Conversation with ChatGPT',
+            genericTitlePattern: /^(chatgpt|new chat|untitled|chat)$/i,
+            messageSelectors: [
+                'div[data-message-author-role]',
+                'article[data-testid*="conversation-turn"]',
+                'div[data-testid="conversation-turn"]',
+                '.group\\/conversation-turn',
+                '[data-testid*="message"], [data-message-id], [data-message-author]'
+            ],
+            contentSelectors: [
+                '.markdown, .prose, [class*="markdown"], [class*="prose"]',
+                '[data-message-content], [data-testid*="content"]',
+                '.whitespace-pre-wrap, [class*="whitespace"]'
+            ],
+            titleSelectors: [
+                'h1:not([class*="hidden"])',
+                '[class*="conversation-title"]',
+                '[data-testid*="conversation-title"]'
+            ]
+        },
+        gemini: {
+            id: 'gemini',
+            assistantName: 'Gemini',
+            sourceLabel: 'gemini.google.com',
+            defaultTitle: 'Conversation with Gemini',
+            genericTitlePattern: /^(gemini|new chat|untitled|chat|bard)$/i,
+            messageSelectors: [
+                'user-query, model-response',
+                '[data-test-id="conversation-turn"]',
+                '[data-testid="conversation-turn"]',
+                '[data-message-author-role]',
+                '[class*="conversation-turn"]',
+                '[role="listitem"]'
+            ],
+            contentSelectors: [
+                'message-content',
+                '.query-text',
+                '.response-container',
+                '.markdown, .prose, [class*="markdown"], [class*="prose"]'
+            ],
+            titleSelectors: [
+                'h1:not([class*="hidden"])',
+                '[class*="conversation-title"]',
+                '[data-testid*="conversation-title"]',
+                '[aria-label*="conversation"]'
+            ]
+        }
+    };
+
+    function resolveDocument(doc) {
+        if (doc) return doc;
+        if (typeof document !== 'undefined') return document;
+        throw new Error('ChatExporterEngine requires a document.');
+    }
+
+    function getWindow(doc) {
+        return doc.defaultView || (typeof window !== 'undefined' ? window : null);
+    }
+
+    function formatDate(date = new Date()) {
+        return date.toISOString().split('T')[0];
+    }
+
+    function sanitizeHtml(value) {
+        return String(value ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function normalizeWhitespace(value) {
+        return String(value ?? '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+    }
+
+    function getClassName(element) {
+        const className = element?.className;
+        if (!className) return '';
+        if (typeof className === 'string') return className;
+        return className.baseVal || '';
+    }
+
+    function queryAll(root, selector) {
+        if (!root || !selector) return [];
+
+        try {
+            return Array.from(root.querySelectorAll(selector));
+        } catch (error) {
+            console.warn('[Chat Exporter] Selector failed:', selector, error);
+            return [];
+        }
+    }
+
+    function matches(element, selector) {
+        if (!element || !selector || typeof element.matches !== 'function') return false;
+
+        try {
+            return element.matches(selector);
+        } catch (error) {
+            return false;
+        }
+    }
+
+    function getText(element) {
+        if (!element) return '';
+        const innerText = typeof element.innerText === 'string' ? element.innerText : '';
+        return (innerText || element.textContent || '').replace(/\u00a0/g, ' ').trim();
+    }
+
+    function collectTextWithBreaks(node) {
+        if (!node) return '';
+
+        if (node.nodeType === 3) {
+            return node.nodeValue || '';
+        }
+
+        if (node.nodeType !== 1) {
+            return '';
+        }
+
+        const tag = node.tagName.toLowerCase();
+        if (tag === 'br') return '\n';
+        if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+
+        const before = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+        const after = ['div', 'p', 'li', 'tr', 'section', 'article'].includes(tag) ? '\n' : '';
+        return before + Array.from(node.childNodes).map(collectTextWithBreaks).join('') + after;
+    }
+
+    function getCodeText(element) {
+        if (!element) return '';
+
+        if (typeof element.innerText === 'string' && element.innerText.trim()) {
+            return element.innerText.replace(/\u00a0/g, ' ').replace(/\n{3,}/g, '\n\n').trimEnd();
+        }
+
+        const clone = element.cloneNode(true);
+        queryAll(clone, 'br').forEach(br => br.replaceWith(clone.ownerDocument.createTextNode('\n')));
+        return collectTextWithBreaks(clone).replace(/\n{3,}/g, '\n\n').trimEnd();
+    }
+
+    function normalizeCodeText(value) {
+        return String(value ?? '')
+            .replace(/\r\n?/g, '\n')
+            .replace(/^\n+/, '')
+            .replace(/\n+$/, '');
+    }
+
+    function createTextNode(reference, text) {
+        return reference.ownerDocument.createTextNode(text);
+    }
+
+    function addReplacement(replacements, html) {
+        const marker = `${MARKER_PREFIX}${replacements.length}__`;
+        replacements.push({ marker, html });
+        return marker;
+    }
+
+    function restoreReplacements(value, replacements) {
+        return replacements.reduce((result, replacement) => result.replaceAll(replacement.marker, replacement.html), value);
+    }
+
+    function cleanMarkdown(markdown) {
+        return String(markdown ?? '')
+            .split(/(```[\s\S]*?```)/g)
+            .map(part => part.startsWith('```')
+                ? part
+                : part
+                    .replace(/[ \t]+\n/g, '\n')
+                    .replace(/\n[ \t]+/g, '\n')
+                    .replace(/\n{3,}/g, '\n\n')
+                    .replace(/&lt;/g, '<')
+                    .replace(/&gt;/g, '>')
+                    .replace(/&amp;/g, '&'))
+            .join('')
+            .replace(/\n{3,}/g, '\n\n')
+            .trim();
+    }
+
+    function escapeMarkdownLinkText(value) {
+        return String(value ?? '')
+            .replace(/\\/g, '\\\\')
+            .replace(/([\[\]])/g, '\\$1');
+    }
+
+    function escapeMarkdownUrl(value) {
+        return String(value ?? '')
+            .replace(/\\/g, '%5C')
+            .replace(/\)/g, '%29');
+    }
+
+    function isUnsafeHref(href) {
+        const lower = String(href || '').trim().toLowerCase();
+        return !lower ||
+            lower.startsWith('javascript:') ||
+            lower.startsWith('data:') ||
+            lower.startsWith('vbscript:') ||
+            lower.startsWith('#');
+    }
+
+    function topLevelElements(elements) {
+        return elements.filter(element => !elements.some(other => other !== element && other.contains(element)));
+    }
+
+    function removeUiElements(clone) {
+        const uiSelector = [
+            'button',
+            'svg',
+            'style',
+            'script',
+            'textarea',
+            'input',
+            '[contenteditable="true"]',
+            '[class*="regenerate"]',
+            '[class*="copy-button"]',
+            '[data-testid*="copy"]',
+            '[data-test-id*="copy"]',
+            '[aria-label*="Copy"]',
+            '[aria-label*="copy"]',
+            '[aria-label*="More"]',
+            '[aria-label*="more"]'
+        ].join(',');
+
+        queryAll(clone, uiSelector).forEach(element => element.remove());
+    }
+
+    function detectLanguage(block) {
+        const codeElement = matches(block, 'code') ? block : block.querySelector('code');
+        const sources = [
+            codeElement?.className,
+            block.getAttribute?.('data-language'),
+            block.getAttribute?.('language'),
+            block.getAttribute?.('lang'),
+            codeElement?.getAttribute?.('data-language'),
+            codeElement?.getAttribute?.('language'),
+            codeElement?.getAttribute?.('lang'),
+            block.getAttribute?.('aria-label')
+        ].filter(Boolean).map(String);
+
+        for (const source of sources) {
+            const languageMatch = source.match(/language-([a-zA-Z0-9_+#.-]+)/);
+            if (languageMatch) return languageMatch[1].toLowerCase();
+            if (/^[a-zA-Z0-9_+#.-]{1,24}$/.test(source) && !/^(code|copy|download)$/i.test(source)) {
+                return source.toLowerCase();
+            }
+        }
+
+        const header = block.querySelector('[class*="sticky"], [class*="code-header"], [data-testid*="code"], [data-test-id*="code"], .code-language, .code-lang, [slot="header"]');
+        const headerText = normalizeWhitespace(getText(header)).replace(/\b(copy|code|download)\b/gi, '').trim();
+        if (headerText && headerText.length < 32 && !headerText.includes('\n')) {
+            return headerText.toLowerCase();
+        }
+
+        return '';
+    }
+
+    function extractCodeBlock(block) {
+        const clone = block.cloneNode(true);
+        const language = detectLanguage(clone);
+
+        queryAll(clone, 'button, svg, [aria-label*="Copy"], [aria-label*="copy"], [class*="sticky"], [class*="code-header"], [data-testid*="copy"], [data-test-id*="copy"], [slot="header"]').forEach(element => element.remove());
+
+        const cmContent = clone.querySelector('.cm-content');
+        if (cmContent) {
+            const cmLines = queryAll(cmContent, '.cm-line');
+            if (cmLines.length > 0) {
+                return {
+                    lang: language,
+                    code: normalizeCodeText(cmLines.map(line => line.textContent || '').join('\n'))
+                };
+            }
+
+            return {
+                lang: language,
+                code: normalizeCodeText(getCodeText(cmContent))
+            };
+        }
+
+        const codeElement = matches(clone, 'code') ? clone : clone.querySelector('code');
+        return {
+            lang: language,
+            code: normalizeCodeText(getCodeText(codeElement || clone))
+        };
+    }
+
+    function formatCodeBlock(block, format, replacements) {
+        const { lang, code } = extractCodeBlock(block);
+
+        if (format === 'markdown') {
+            return `\n\n\`\`\`${lang}\n${code}\n\`\`\`\n\n`;
+        }
+
+        const langClass = lang ? ` class="language-${sanitizeHtml(lang)}"` : '';
+        if (format === 'pdf') {
+            const label = lang ? `<div class="code-language">${sanitizeHtml(lang)}</div>` : '';
+            return addReplacement(replacements, `<pre class="code-block">${label}<code>${sanitizeHtml(code)}</code></pre>`);
+        }
+
+        return addReplacement(replacements, `<pre><code${langClass}>${sanitizeHtml(code)}</code></pre>`);
+    }
+
+    function processCodeBlocks(clone, format, replacements) {
+        const blocks = topLevelElements(queryAll(clone, 'pre, code-block, [data-testid*="code-block"], [data-test-id*="code-block"]'));
+
+        blocks.forEach(block => {
+            const replacement = formatCodeBlock(block, format, replacements);
+            block.replaceWith(createTextNode(block, replacement));
+        });
+    }
+
+    function processMath(clone) {
+        const processed = new Set();
+
+        queryAll(clone, 'annotation').forEach(annotation => {
+            const encoding = (annotation.getAttribute('encoding') || '').toLowerCase();
+            if (!encoding.includes('tex') && !encoding.includes('latex')) return;
+
+            const tex = annotation.textContent.trim();
+            if (!tex) return;
+
+            const displayRoot = annotation.closest('.katex-display, mjx-container[display="true"], [display="block"]');
+            const mathRoot = displayRoot || annotation.closest('.katex') || annotation.closest('mjx-container') || annotation.closest('math');
+            if (!mathRoot || processed.has(mathRoot)) return;
+
+            processed.add(mathRoot);
+            mathRoot.replaceWith(createTextNode(mathRoot, displayRoot ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+        });
+
+        queryAll(clone, 'script[type^="math/tex"]').forEach(script => {
+            const tex = script.textContent.trim();
+            if (!tex) return;
+            const isDisplay = /mode=display/.test(script.type);
+            script.replaceWith(createTextNode(script, isDisplay ? `\n\n$$${tex}$$\n\n` : `$${tex}$`));
+        });
+    }
+
+    function processMedia(clone, format, replacements) {
+        queryAll(clone, 'img, canvas, video, audio').forEach(element => {
+            const tag = element.tagName.toLowerCase();
+            const alt = normalizeWhitespace(element.getAttribute('alt') || element.getAttribute('aria-label') || element.getAttribute('title') || '');
+            const label = tag === 'img' && alt ? `[Image: ${alt}]` :
+                tag === 'img' ? '[Image]' :
+                tag === 'canvas' ? '[Canvas or chart]' :
+                tag === 'video' ? '[Video]' :
+                tag === 'audio' ? '[Audio]' :
+                '[Media]';
+
+            const replacement = format === 'markdown'
+                ? label
+                : addReplacement(replacements, `<span class="media-placeholder">${sanitizeHtml(label)}</span>`);
+            element.replaceWith(createTextNode(element, replacement));
+        });
+    }
+
+    function processLinks(clone, format, replacements) {
+        queryAll(clone, 'a[href]').forEach(link => {
+            if (link.closest('pre, code, code-block')) return;
+
+            const href = String(link.href || link.getAttribute('href') || '').trim();
+            if (isUnsafeHref(href)) return;
+
+            const text = normalizeWhitespace(link.textContent) || href;
+            const replacement = format === 'markdown'
+                ? `[${escapeMarkdownLinkText(text)}](${escapeMarkdownUrl(href)})`
+                : addReplacement(replacements, `<a href="${sanitizeHtml(href)}">${sanitizeHtml(text)}</a>`);
+
+            link.replaceWith(createTextNode(link, replacement));
+        });
+    }
+
+    function tableCellText(cell) {
+        return normalizeWhitespace(getText(cell)).replace(/\|/g, '\\|') || ' ';
+    }
+
+    function tableToMarkdown(table) {
+        const rows = queryAll(table, 'tr')
+            .map(row => Array.from(row.children)
+                .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                .map(tableCellText))
+            .filter(row => row.length > 0);
+
+        if (rows.length === 0) return normalizeWhitespace(getText(table));
+
+        const width = Math.max(...rows.map(row => row.length));
+        const normalizedRows = rows.map(row => row.concat(Array(Math.max(0, width - row.length)).fill(' ')));
+        const header = normalizedRows[0];
+        const separator = header.map(() => '---');
+        const body = normalizedRows.slice(1);
+
+        return [
+            `| ${header.join(' | ')} |`,
+            `| ${separator.join(' | ')} |`,
+            ...body.map(row => `| ${row.join(' | ')} |`)
+        ].join('\n');
+    }
+
+    function tableToHtml(table) {
+        const rows = queryAll(table, 'tr')
+            .map(row => Array.from(row.children)
+                .filter(cell => ['TH', 'TD'].includes(cell.tagName))
+                .map(cell => ({
+                    tag: cell.tagName.toLowerCase(),
+                    text: normalizeWhitespace(getText(cell))
+                })))
+            .filter(row => row.length > 0);
+
+        if (rows.length === 0) return sanitizeHtml(getText(table));
+
+        return `<table>${rows.map(row => {
+            const cells = row.map(cell => `<${cell.tag}>${sanitizeHtml(cell.text)}</${cell.tag}>`).join('');
+            return `<tr>${cells}</tr>`;
+        }).join('')}</table>`;
+    }
+
+    function processTables(clone, format, replacements) {
+        topLevelElements(queryAll(clone, 'table')).forEach(table => {
+            const replacement = format === 'markdown'
+                ? `\n\n${tableToMarkdown(table)}\n\n`
+                : addReplacement(replacements, tableToHtml(table));
+            table.replaceWith(createTextNode(table, replacement));
+        });
+    }
+
+    function cardSignal(element) {
+        const pieces = [
+            element.tagName,
+            getClassName(element),
+            element.getAttribute('data-testid'),
+            element.getAttribute('data-test-id'),
+            element.getAttribute('aria-label'),
+            element.getAttribute('role')
+        ].filter(Boolean).join(' ').toLowerCase();
+
+        if (/\b(artifact|canvas-preview|generated-file|download-card|attachment|file-card)\b/.test(pieces)) {
+            return pieces.includes('artifact') || pieces.includes('canvas-preview') ? 'Artifact' : 'File';
+        }
+
+        if (/(^|[\s_-])(attachment|file)([\s_-]|$)/.test(pieces)) {
+            return 'File';
+        }
+
+        return '';
+    }
+
+    function cardLabel(element) {
+        const candidates = [
+            element.getAttribute('aria-label'),
+            element.getAttribute('title'),
+            element.getAttribute('download'),
+            element.getAttribute('data-filename'),
+            getText(element)
+        ].filter(Boolean).map(normalizeWhitespace);
+
+        const label = candidates.find(value => value && value.length <= 180) || '';
+        return label
+            .replace(/\b(open|download|preview|file|attachment|artifact)\b/gi, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+
+    function processCards(clone, format, replacements) {
+        const cards = topLevelElements(Array.from(clone.querySelectorAll('*')).filter(element => {
+            const kind = cardSignal(element);
+            if (!kind) return false;
+            if (matches(element, '[data-message-author-role], user-query, model-response')) return false;
+            if (element.closest('pre, code, code-block, table')) return false;
+            if (element.querySelector('pre, code-block, table, user-query, model-response')) return false;
+
+            const text = normalizeWhitespace(getText(element));
+            const label = cardLabel(element);
+            return Boolean(label || text) && text.length <= 240;
+        }));
+
+        cards.forEach(card => {
+            const kind = cardSignal(card);
+            const label = cardLabel(card);
+            const text = label ? `[${kind}: ${label}]` : `[${kind}]`;
+            const replacement = format === 'markdown'
+                ? text
+                : addReplacement(replacements, `<span class="card-placeholder">${sanitizeHtml(text)}</span>`);
+            card.replaceWith(createTextNode(card, replacement));
+        });
+    }
+
+    function serializeMarkdownChildren(element, context = {}) {
+        return Array.from(element.childNodes).map((node, index) => serializeMarkdownNode(node, {
+            ...context,
+            index
+        })).join('');
+    }
+
+    function serializeMarkdownNode(node, context = {}) {
+        if (node.nodeType === 3) {
+            const value = node.nodeValue || '';
+            if (value.includes('```') || value.includes('| ---') || value.includes(MARKER_PREFIX) || value.match(/^\s*\[[^\]]+\]/)) {
+                return value;
+            }
+            return value.replace(/[ \t\r\n]+/g, ' ');
+        }
+
+        if (node.nodeType !== 1) return '';
+
+        const tag = node.tagName.toLowerCase();
+        if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+        if (tag === 'br') return '\n';
+
+        if (/^h[1-6]$/.test(tag)) {
+            const level = Number(tag.slice(1));
+            const content = serializeMarkdownChildren(node, context).trim();
+            return content ? `\n\n${'#'.repeat(level)} ${content}\n\n` : '';
+        }
+
+        if (tag === 'p') {
+            const content = serializeMarkdownChildren(node, context).trim();
+            return content ? `\n\n${content}\n\n` : '';
+        }
+
+        if (tag === 'blockquote') {
+            const content = serializeMarkdownChildren(node, context).trim();
+            return content ? `\n\n${content.split('\n').map(line => `> ${line.trim()}`).join('\n')}\n\n` : '';
+        }
+
+        if (tag === 'ul' || tag === 'ol') {
+            const children = Array.from(node.children).filter(child => child.tagName && child.tagName.toLowerCase() === 'li');
+            return `\n${children.map((child, index) => serializeMarkdownNode(child, {
+                ...context,
+                listType: tag,
+                index,
+                depth: (context.depth || 0)
+            })).join('')}\n`;
+        }
+
+        if (tag === 'li') {
+            const depth = context.depth || 0;
+            const marker = context.listType === 'ol' ? `${(context.index || 0) + 1}. ` : '- ';
+            const indent = '  '.repeat(depth);
+            const content = serializeMarkdownChildren(node, {
+                ...context,
+                depth: depth + 1
+            }).trim();
+            return content ? `${indent}${marker}${content.replace(/\n+/g, `\n${indent}  `)}\n` : '';
+        }
+
+        if (['strong', 'b'].includes(tag)) {
+            const content = serializeMarkdownChildren(node, context).trim();
+            return content ? `**${content}**` : '';
+        }
+
+        if (['em', 'i'].includes(tag)) {
+            const content = serializeMarkdownChildren(node, context).trim();
+            return content ? `*${content}*` : '';
+        }
+
+        if (tag === 'code') {
+            const content = getCodeText(node).replace(/`/g, '\\`').trim();
+            return content ? `\`${content}\`` : '';
+        }
+
+        const content = serializeMarkdownChildren(node, context);
+        if (['div', 'section', 'article', 'main', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+            return content;
+        }
+
+        return content;
+    }
+
+    function serializeHtmlChildren(element, replacements) {
+        return Array.from(element.childNodes).map(node => serializeHtmlNode(node, replacements)).join('');
+    }
+
+    function serializeHtmlNode(node, replacements) {
+        if (node.nodeType === 3) {
+            return sanitizeHtml(node.nodeValue || '');
+        }
+
+        if (node.nodeType !== 1) return '';
+
+        const tag = node.tagName.toLowerCase();
+        if (['script', 'style', 'button', 'svg'].includes(tag)) return '';
+        if (tag === 'br') return '<br>';
+
+        const content = serializeHtmlChildren(node, replacements);
+        const blockTags = new Set(['p', 'ul', 'ol', 'li', 'blockquote', 'strong', 'b', 'em', 'i']);
+
+        if (/^h[1-6]$/.test(tag)) {
+            return `<${tag}>${content}</${tag}>`;
+        }
+
+        if (blockTags.has(tag)) {
+            const safeTag = tag === 'b' ? 'strong' : tag === 'i' ? 'em' : tag;
+            return `<${safeTag}>${content}</${safeTag}>`;
+        }
+
+        if (tag === 'code') {
+            return `<code>${sanitizeHtml(getCodeText(node).trim())}</code>`;
+        }
+
+        if (['div', 'section', 'article', 'main', 'span', 'message-content', 'model-response', 'user-query', 'response-element'].includes(tag)) {
+            return content;
+        }
+
+        return content;
+    }
+
+    function serializeMessageContent(element, format) {
+        const clone = element.cloneNode(true);
+        const replacements = [];
+
+        removeUiElements(clone);
+        processCards(clone, format, replacements);
+        processCodeBlocks(clone, format, replacements);
+        processMath(clone);
+        processMedia(clone, format, replacements);
+        processLinks(clone, format, replacements);
+        processTables(clone, format, replacements);
+
+        if (format === 'markdown') {
+            return cleanMarkdown(serializeMarkdownChildren(clone));
+        }
+
+        const html = serializeHtmlChildren(clone, replacements)
+            .replace(/\n{3,}/g, '\n\n')
+            .trim();
+        return restoreReplacements(html, replacements);
+    }
+
+    function detectProvider(doc) {
+        const url = doc.defaultView?.location?.href || '';
+        if (/gemini\.google\.com/i.test(url) || doc.querySelector('user-query, model-response')) return 'gemini';
+        return 'chatgpt';
+    }
+
+    function providerFor(providerName, doc) {
+        const id = providerName || detectProvider(doc);
+        return PROVIDERS[id] || PROVIDERS.chatgpt;
+    }
+
+    function meaningfulScore(element) {
+        const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+        return normalizeWhitespace(element.textContent).length + richCount * 200;
+    }
+
+    function isValidMessage(element) {
+        const text = normalizeWhitespace(element.textContent);
+        const richCount = queryAll(element, 'pre, code-block, table, img, canvas, video, audio, annotation, script[type^="math/tex"]').length;
+
+        if (text.length < 5 && richCount === 0) return false;
+        if (text.length > 200000) return false;
+        if (matches(element, 'nav, aside, header, footer, form, menu')) return false;
+        if (element.querySelector('textarea, input[type="text"], [contenteditable="true"]') && !element.hasAttribute('data-message-author-role')) return false;
+        if (getClassName(element).match(/\b(typing|loading|spinner)\b/i)) return false;
+
+        return true;
+    }
+
+    function findMessages(doc, provider) {
+        for (const selector of provider.messageSelectors) {
+            const messages = topLevelElements(queryAll(doc, selector)).filter(isValidMessage);
+            if (messages.length > 0) {
+                console.log(`[Chat Exporter] ${provider.id}: using selector "${selector}" (${messages.length} messages)`);
+                return messages;
+            }
+        }
+
+        const container = doc.querySelector('[role="main"], main, [class*="conversation"], [class*="chat"]');
+        if (!container) return [];
+
+        return topLevelElements(queryAll(container, ':scope > article, :scope > section, :scope > div')).filter(isValidMessage);
+    }
+
+    function selectContentRoot(messageElement, provider) {
+        const candidates = [messageElement];
+
+        provider.contentSelectors.forEach(selector => {
+            if (matches(messageElement, selector)) candidates.push(messageElement);
+            candidates.push(...queryAll(messageElement, selector));
+        });
+
+        return candidates
+            .filter(Boolean)
+            .sort((a, b) => meaningfulScore(b) - meaningfulScore(a))[0] || messageElement;
+    }
+
+    function identifySender(element, index, provider) {
+        const tag = element.tagName.toLowerCase();
+        if (tag === 'user-query') return { sender: 'You', reliable: true };
+        if (tag === 'model-response') return { sender: provider.assistantName, reliable: true };
+
+        const role = element.getAttribute('data-message-author-role') || element.getAttribute('data-author') || element.getAttribute('data-sender');
+        if (role) {
+            const normalizedRole = role.toLowerCase();
+            if (normalizedRole === 'user') return { sender: 'You', reliable: true };
+            if (['assistant', 'model', 'bot', 'chatgpt', 'gemini'].includes(normalizedRole)) {
+                return { sender: provider.assistantName, reliable: true };
+            }
+        }
+
+        const classAndAttrs = [
+            getClassName(element),
+            element.getAttribute('aria-label'),
+            element.getAttribute('data-testid'),
+            element.getAttribute('data-test-id')
+        ].filter(Boolean).join(' ').toLowerCase();
+
+        if (classAndAttrs.match(/\b(user|human|query)\b/)) return { sender: 'You', reliable: false };
+        if (classAndAttrs.match(/\b(assistant|model|response|chatgpt|gemini|bard)\b/)) return { sender: provider.assistantName, reliable: false };
+
+        const textStart = normalizeWhitespace(element.textContent).slice(0, 220).toLowerCase();
+        if (/^(i understand|i can help|here's|i'll|let me|i'd be happy|certainly|of course|absolutely)/.test(textStart)) {
+            return { sender: provider.assistantName, reliable: false };
+        }
+
+        if (/^(can you|please help|how do i|i need|i want|help me|could you|explain|what is)/.test(textStart)) {
+            return { sender: 'You', reliable: false };
+        }
+
+        return { sender: index % 2 === 0 ? 'You' : provider.assistantName, reliable: false };
+    }
+
+    function contentHash(content) {
+        return normalizeWhitespace(String(content || '').replace(/<[^>]+>/g, ' ')).slice(0, 160);
+    }
+
+    function extractConversation(options = {}) {
+        const doc = resolveDocument(options.document);
+        const provider = providerFor(options.provider, doc);
+        const format = options.format || 'markdown';
+        const rawMessages = findMessages(doc, provider);
+        const seen = new Set();
+        const messages = [];
+
+        rawMessages.forEach((messageElement, index) => {
+            const contentRoot = selectContentRoot(messageElement, provider);
+            const content = serializeMessageContent(contentRoot, format);
+            const minLength = queryAll(contentRoot, 'pre, code-block, table, img, canvas, video, audio').length > 0 ? 3 : 10;
+
+            if (!content || content.replace(/<[^>]*>/g, '').trim().length < minLength) return;
+
+            const hash = contentHash(content);
+            if (seen.has(hash)) return;
+            seen.add(hash);
+
+            const sender = identifySender(messageElement, index, provider);
+            messages.push({
+                sender: sender.sender,
+                senderType: sender.sender === 'You' ? 'user' : 'assistant',
+                reliableSender: sender.reliable,
+                content,
+                index
+            });
+        });
+
+        return {
+            version: ENGINE_VERSION,
+            provider: provider.id,
+            providerLabel: provider.assistantName,
+            sourceLabel: provider.sourceLabel,
+            title: extractConversationTitle(doc, provider),
+            sourceUrl: doc.defaultView?.location?.href || '',
+            date: formatDate(options.date || new Date()),
+            messages
+        };
+    }
+
+    function extractConversationTitle(doc, provider) {
+        for (const selector of provider.titleSelectors) {
+            const element = doc.querySelector(selector);
+            const title = normalizeWhitespace(element?.textContent);
+            if (title && !provider.genericTitlePattern.test(title)) return title;
+        }
+
+        const docTitle = normalizeWhitespace(doc.title);
+        if (docTitle && !provider.genericTitlePattern.test(docTitle)) return docTitle;
+
+        return provider.defaultTitle;
+    }
+
+    function renderMarkdown(conversation) {
+        const lines = [
+            `# ${conversation.title}\n`,
+            `**Date:** ${conversation.date}`,
+            `**Source:** [${conversation.sourceLabel}](${conversation.sourceUrl})\n`,
+            '---\n'
+        ];
+
+        conversation.messages.forEach(message => {
+            lines.push(`### **${message.sender}**\n`, message.content, '\n---\n');
+        });
+
+        return `${lines.join('\n').trim()}\n`;
+    }
+
+    function renderHtmlDocument(conversation, options = {}) {
+        const isPdf = options.format === 'pdf';
+        const source = sanitizeHtml(conversation.sourceUrl);
+        const title = sanitizeHtml(conversation.title);
+        const messages = conversation.messages.map(message => {
+            const senderClass = message.senderType === 'user' ? 'user' : 'assistant';
+            return `
+        <div class="message ${senderClass}">
+            <div class="sender">${sanitizeHtml(message.sender)}</div>
+            <div class="content">${message.content}</div>
+        </div>`;
+        }).join('');
+
+        const pdfInstructions = isPdf ? `
+    <div class="instructions no-print">
+        <h3>Convert to PDF</h3>
+        <ol>
+            <li>Press Ctrl+P on Windows/Linux or Cmd+P on Mac.</li>
+            <li>Set Destination to Save as PDF.</li>
+            <li>Choose your preferred page size.</li>
+            <li>Click Save.</li>
+        </ol>
+        <p><em>This instruction box will not appear in the PDF.</em></p>
+    </div>` : '';
+
+        return `<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>${title} - ${conversation.date}</title>
+    <style>
+        @media print {
+            body { margin: 0; }
+            .no-print { display: none; }
+            .message { page-break-inside: avoid; }
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+            max-width: 840px;
+            margin: auto;
+            padding: 2rem;
+            background: #fff;
+            color: #333;
+            line-height: 1.6;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 2rem;
+            padding-bottom: 1rem;
+            border-bottom: 2px solid #eee;
+        }
+        .metadata {
+            color: #666;
+            font-size: 0.9rem;
+        }
+        .message {
+            margin-bottom: 1.5rem;
+            padding: 1rem;
+            border-radius: 8px;
+            background: #f8f9fa;
+        }
+        .message.user {
+            background: #eaf4ff;
+        }
+        .sender {
+            font-weight: 700;
+            color: #2c3e50;
+            margin-bottom: 0.5rem;
+        }
+        .content {
+            white-space: pre-wrap;
+            overflow-wrap: anywhere;
+        }
+        pre {
+            background: #f4f4f4;
+            padding: 1rem;
+            border-radius: 4px;
+            overflow-x: auto;
+            border-left: 4px solid #007acc;
+        }
+        .code-block {
+            background: #282c34;
+            color: #abb2bf;
+            border-left: 0;
+        }
+        .code-block code {
+            white-space: pre;
+        }
+        .code-language {
+            color: #d7dae0;
+            font-size: 12px;
+            margin-bottom: 8px;
+            text-transform: uppercase;
+        }
+        code {
+            font-family: Consolas, Monaco, "Courier New", monospace;
+            font-size: 0.92rem;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1rem 0;
+        }
+        th, td {
+            border: 1px solid #d9dde3;
+            padding: 0.5rem;
+            text-align: left;
+            vertical-align: top;
+        }
+        th {
+            background: #eef2f7;
+        }
+        .instructions {
+            background: #fff8dc;
+            border: 1px solid #e3c565;
+            border-radius: 8px;
+            padding: 1rem;
+            margin-bottom: 1.5rem;
+        }
+    </style>
+</head>
+<body>
+    ${pdfInstructions}
+    <div class="header">
+        <h1>${title}</h1>
+        <div class="metadata">
+            <div><strong>Date:</strong> ${sanitizeHtml(conversation.date)}</div>
+            <div><strong>Source:</strong> <a href="${source}">${sanitizeHtml(conversation.sourceLabel)}</a></div>
+            <div><strong>Messages:</strong> ${conversation.messages.length}</div>
+        </div>
+    </div>
+    <div class="conversation">${messages}
+    </div>
+</body>
+</html>`;
+    }
+
+    function render(conversation, format) {
+        if (format === 'markdown') return renderMarkdown(conversation);
+        if (format === 'pdf') return renderHtmlDocument(conversation, { format: 'pdf' });
+        if (format === 'html') return renderHtmlDocument(conversation, { format: 'html' });
+        throw new Error(`Unsupported export format: ${format}`);
+    }
+
+    function filenameFor(conversation, format, doc) {
+        const safeTitle = normalizeWhitespace(doc.title || conversation.title)
+            .replace(/[<>:"/\\|?*]/g, '')
+            .slice(0, 120);
+
+        if (format === 'markdown') {
+            return safeTitle ? `${safeTitle} (${conversation.date}).md` : `${conversation.providerLabel}_Conversation_${conversation.date}.md`;
+        }
+
+        if (format === 'pdf') {
+            return safeTitle ? `${safeTitle} (${conversation.date}) - PrintToPDF.html` : `${conversation.providerLabel}_Conversation_${conversation.date}_PrintToPDF.html`;
+        }
+
+        return safeTitle ? `${safeTitle} (${conversation.date}).html` : `${conversation.providerLabel}_Conversation_${conversation.date}.html`;
+    }
+
+    function mimeFor(format) {
+        return format === 'markdown' ? 'text/markdown' : 'text/html';
+    }
+
+    function downloadFile(doc, content, filename, mimeType) {
+        const win = getWindow(doc);
+        const BlobCtor = win?.Blob || Blob;
+        const urlApi = win?.URL || URL;
+        const blob = new BlobCtor([content], { type: mimeType });
+        const url = urlApi.createObjectURL(blob);
+        const anchor = doc.createElement('a');
+
+        anchor.href = url;
+        anchor.download = filename;
+        doc.body.appendChild(anchor);
+        anchor.click();
+        doc.body.removeChild(anchor);
+        urlApi.revokeObjectURL(url);
+    }
+
+    function exportConversation(options = {}) {
+        const doc = resolveDocument(options.document);
+        const format = options.format || 'markdown';
+        const conversation = extractConversation({
+            ...options,
+            document: doc,
+            format
+        });
+
+        if (conversation.messages.length === 0) {
+            const message = 'No messages found. The page structure may have changed.';
+            const win = getWindow(doc);
+            if (typeof win?.alert === 'function') win.alert(message);
+            console.warn(`[Chat Exporter] ${message}`);
+            return { conversation, content: '' };
+        }
+
+        const content = render(conversation, format);
+        const filename = options.filename || filenameFor(conversation, format, doc);
+
+        if (options.download !== false) {
+            downloadFile(doc, content, filename, mimeFor(format));
+            console.log(`[Chat Exporter] Exported ${conversation.messages.length} messages to ${filename}`);
+        }
+
+        return { conversation, content, filename };
+    }
+
+    return {
+        version: ENGINE_VERSION,
+        providers: PROVIDERS,
+        detectProvider,
+        extractConversation,
+        exportConversation,
+        serializers: {
+            markdown: renderMarkdown,
+            html: conversation => renderHtmlDocument(conversation, { format: 'html' }),
+            pdf: conversation => renderHtmlDocument(conversation, { format: 'pdf' })
+        },
+        internals: {
+            serializeMessageContent,
+            extractCodeBlock,
+            tableToMarkdown,
+            tableToHtml
+        }
+    };
+});

--- a/temporal/current-state.md
+++ b/temporal/current-state.md
@@ -1,5 +1,7 @@
 ## Current State Analysis
 
+> v0.7.0 update: the major selector/content extraction issues listed below have been addressed by the shared extraction engine in `src/extraction-engine.js`, generated console/userscript outputs, and synthetic live-shape tests. This document is retained as historical planning context.
+
 ### **Identified Issues:**
 
 1. **Fragile DOM Selectors**: The code relies on CSS classes like `.text-base`, `div[class*="group"]`, `.markdown`, `.prose`, `.whitespace-pre-wrap` which are likely to break when OpenAI updates ChatGPT's interface.
@@ -27,20 +29,20 @@
 *Priority: Critical*
 
 **1.1 ChatGPT Interface Analysis**
-- [ ] Inspect current ChatGPT DOM structure across different conversation types
-- [ ] Identify stable selectors and data attributes
-- [ ] Document conversation flow patterns and message containers
-- [ ] Test with various conversation types (text, code, images, files, plugins)
+- [x] Inspect current ChatGPT DOM structure across representative live synthetic conversations
+- [x] Identify stable selectors and data attributes
+- [x] Document conversation flow patterns and message containers
+- [x] Test with representative text, code, image/media, table, math, file/card, and artifact-like synthetic structures
 
 **1.2 Selector Modernization**
-- [ ] Replace fragile CSS class selectors with more robust alternatives
-- [ ] Implement fallback selector strategies
-- [ ] Add selector validation and graceful degradation
-- [ ] Create selector mapping for different ChatGPT interface versions
+- [x] Replace fragile CSS class selectors with more robust alternatives
+- [x] Implement fallback selector strategies
+- [x] Add selector validation and graceful degradation
+- [x] Create provider selector mapping for current ChatGPT and Gemini interfaces
 
 **1.3 Message Detection Overhaul**
-- [ ] Unify message detection logic between markdown and PDF exporters
-- [ ] Implement reliable sender identification (You vs ChatGPT vs System)
+- [x] Unify message detection logic between markdown, HTML, PDF, Gemini, and userscript exporters
+- [x] Implement reliable sender identification (You vs ChatGPT/Gemini)
 - [ ] Add support for system messages and conversation metadata
 - [ ] Handle edge cases (deleted messages, loading states, errors)
 
@@ -48,10 +50,10 @@
 *Priority: High*
 
 **2.1 Content Extraction Improvement**
-- [ ] Enhanced code block detection with language identification
-- [ ] Better handling of nested HTML structures
-- [ ] Support for ChatGPT's rich content (tables, lists, formatting)
-- [ ] Improved image and media placeholder handling
+- [x] Enhanced code block detection with language identification
+- [x] Better handling of nested HTML structures
+- [x] Support for ChatGPT's rich content (tables, lists, formatting)
+- [x] Improved image, media, file, and artifact placeholder handling
 
 **2.2 Markdown Processing**
 - [ ] Fix markdown escaping issues

--- a/temporal/release-notes-v0.7.0.md
+++ b/temporal/release-notes-v0.7.0.md
@@ -1,0 +1,23 @@
+# Release Notes - v0.7.0
+
+## Summary
+
+v0.7.0 rewrites ChatGPT and Gemini extraction around a shared provider-based engine. The work is informed by a local live Chrome/Crawlio compatibility audit of current `chatgpt.com` and `gemini.google.com/app` rendering. Raw authenticated captures remain private, ignored, and are not included in the repository.
+
+## Highlights
+
+- Added `src/extraction-engine.js` as the canonical extraction and serialization engine.
+- Added `scripts/build-exporters.js` to embed the shared engine into all pasteable console scripts and ChatGPT userscripts.
+- Updated ChatGPT discovery to prioritize `div[data-message-author-role]` and preserve current CodeMirror code blocks, tables, TeX annotations, media placeholders, and basic file/artifact cards.
+- Updated Gemini discovery to prioritize current `user-query`, `model-response`, `message-content`, and custom `code-block` structures.
+- Added synthetic live-shape fixtures for ChatGPT and Gemini that model observed DOM structures without publishing private capture data.
+- Expanded `npm test` so it verifies generated scripts are current before running jsdom exporter coverage.
+
+## Privacy Note
+
+The local audit used authenticated Chrome and Crawlio Agent captures. Public repository artifacts contain only generalized findings, synthetic fixtures, docs, tests, and code.
+
+## Validation
+
+- `npm run build`
+- `npm test`

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -3,11 +3,16 @@ const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 const { JSDOM } = require('jsdom');
+const engine = require('../src/extraction-engine.js');
 
 const repoRoot = path.resolve(__dirname, '..');
 
 function readScript(filename) {
     return fs.readFileSync(path.join(repoRoot, filename), 'utf8');
+}
+
+function readFixture(filename) {
+    return fs.readFileSync(path.join(repoRoot, 'test', 'fixtures', filename), 'utf8');
 }
 
 function chatGptFixture() {
@@ -136,6 +141,39 @@ test('ChatGPT markdown exporter preserves CodeMirror code, MathJax, tables, link
     assert.doesNotMatch(content, /\\\\mu/);
 });
 
+test('shared engine serializes live-observed ChatGPT shapes from synthetic fixture', () => {
+    const dom = new JSDOM(readFixture('chatgpt-live-shapes.html'), {
+        url: 'https://chatgpt.com/c/live-shapes'
+    });
+
+    const result = engine.extractConversation({
+        document: dom.window.document,
+        provider: 'chatgpt',
+        format: 'markdown'
+    });
+
+    assert.equal(result.provider, 'chatgpt');
+    assert.equal(result.messages.length, 2);
+    assert.equal(result.messages[0].sender, 'You');
+    assert.equal(result.messages[1].sender, 'ChatGPT');
+
+    const content = result.messages[1].content;
+    assert.match(content, /## Audit Heading/);
+    assert.match(content, /\*\*Bold\*\*/);
+    assert.match(content, /\*italic\*/);
+    assert.match(content, /\$\\sigma\^2\$/);
+    assert.match(content, /\$\$y=x\^2\$\$/);
+    assert.match(content, /```typescript\nconst value = 1;\nconsole\.log\(value\);\n```/);
+    assert.match(content, /\| Feature \| Status \| Notes \|/);
+    assert.match(content, /- Parent item/);
+    assert.match(content, /- Child item/);
+    assert.match(content, /> Quoted synthetic result\./);
+    assert.match(content, /\[Doc \\\[A\\\]\]\(https:\/\/example\.com\/a%29b\)/);
+    assert.match(content, /\[File: sample-report\.csv\]/);
+    assert.match(content, /\[Artifact: audit-notes\.md\]/);
+    assert.match(content, /\[Image: synthetic chart\]/);
+});
+
 test('ChatGPT HTML exporter restores structured code and table markup', async () => {
     const { content } = await runExporter('exporter-html.js', chatGptFixture());
 
@@ -166,4 +204,30 @@ test('Gemini markdown exporter uses current selectors and rich content extractio
     assert.match(content, /\| Tool \| Status \|/);
     assert.match(content, /\[Gemini home\]\(https:\/\/gemini\.google\.com\/\)/);
     assert.match(content, /\[Canvas or chart\]/);
+});
+
+test('shared engine serializes live-observed Gemini custom elements from synthetic fixture', () => {
+    const dom = new JSDOM(readFixture('gemini-live-shapes.html'), {
+        url: 'https://gemini.google.com/app/live-shapes'
+    });
+
+    const result = engine.extractConversation({
+        document: dom.window.document,
+        provider: 'gemini',
+        format: 'markdown'
+    });
+
+    assert.equal(result.provider, 'gemini');
+    assert.equal(result.messages.length, 2);
+    assert.equal(result.messages[0].sender, 'You');
+    assert.equal(result.messages[1].sender, 'Gemini');
+
+    const content = result.messages[1].content;
+    assert.match(content, /## Gemini Audit/);
+    assert.match(content, /```javascript\nfunction audit\(\) \{\n  return "gemini";\n\}\n```/);
+    assert.match(content, /\| Provider \| Shape \| Status \|/);
+    assert.match(content, /1\. First ordered item/);
+    assert.match(content, /\[Gemini app\]\(https:\/\/gemini\.google\.com\/app\)/);
+    assert.match(content, /\[Canvas or chart\]/);
+    assert.match(content, /\[File: gemini-notes\.txt\]/);
 });

--- a/test/fixtures/chatgpt-live-shapes.html
+++ b/test/fixtures/chatgpt-live-shapes.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head><title>ChatGPT Live Shapes Fixture</title></head>
+<body>
+    <main>
+        <div data-message-author-role="user">
+            <p>Controlled synthetic prompt with headings, math, code, tables, media, files, and artifacts.</p>
+        </div>
+        <div data-message-author-role="assistant">
+            <div class="markdown prose">
+                <h2>Audit Heading</h2>
+                <p>
+                    <strong>Bold</strong> text, <em>italic</em> text, and inline variance
+                    <span class="katex">
+                        <span class="katex-mathml">
+                            <math><semantics><annotation encoding="application/x-tex">\sigma^2</annotation></semantics></math>
+                        </span>
+                        <span class="katex-html">visual sigma squared</span>
+                    </span>.
+                </p>
+                <span class="katex-display">
+                    <span class="katex">
+                        <span class="katex-mathml">
+                            <math><semantics><annotation encoding="application/x-tex">y=x^2</annotation></semantics></math>
+                        </span>
+                        <span class="katex-html">visual equation</span>
+                    </span>
+                </span>
+                <pre>
+                    <div class="sticky top-0"><span>TypeScript</span><button>Copy</button></div>
+                    <div class="cm-editor">
+                        <div class="cm-content"><span>const value = 1;</span><br><span>console.log(value);</span></div>
+                    </div>
+                </pre>
+                <table>
+                    <thead><tr><th>Feature</th><th>Status</th><th>Notes</th></tr></thead>
+                    <tbody><tr><td>Tables</td><td>Stable</td><td>Flatten spans</td></tr></tbody>
+                </table>
+                <ul>
+                    <li>Parent item
+                        <ul><li>Child item</li></ul>
+                    </li>
+                </ul>
+                <blockquote>Quoted synthetic result.</blockquote>
+                <p>See <a href="https://example.com/a)b">Doc [A]</a>.</p>
+                <div data-testid="file-card"><span>sample-report.csv</span><button>Download</button></div>
+                <div data-testid="artifact-card"><span>audit-notes.md</span></div>
+                <img alt="synthetic chart">
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/test/fixtures/gemini-live-shapes.html
+++ b/test/fixtures/gemini-live-shapes.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head><title>Gemini Live Shapes Fixture</title></head>
+<body>
+    <main>
+        <user-query>
+            <div class="query-text">Controlled synthetic Gemini prompt with code, table, media, and file card.</div>
+        </user-query>
+        <model-response>
+            <message-content>
+                <div class="response-container">
+                    <h2>Gemini Audit</h2>
+                    <p><strong>Bold</strong> and <em>italic</em> synthetic response text.</p>
+                    <response-element>
+                        <code-block language="javascript">
+                            <div slot="header">JavaScript</div>
+                            <pre><code>function audit() {
+  return "gemini";
+}</code></pre>
+                        </code-block>
+                    </response-element>
+                    <table>
+                        <tr><th>Provider</th><th>Shape</th><th>Status</th></tr>
+                        <tr><td>Gemini</td><td>code-block</td><td>Observed</td></tr>
+                    </table>
+                    <ol>
+                        <li>First ordered item</li>
+                        <li>Second ordered item</li>
+                    </ol>
+                    <p>Reference <a href="https://gemini.google.com/app">Gemini app</a>.</p>
+                    <canvas aria-label="synthetic chart"></canvas>
+                    <div class="file-card"><span>gemini-notes.txt</span></div>
+                </div>
+            </message-content>
+        </model-response>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a shared provider-based extraction engine and build step that embeds it into every console exporter/userscript
- update ChatGPT and Gemini adapters for live-observed 2026 DOM shapes, including CodeMirror/code-blocks, tables, TeX annotations, links, media placeholders, and file/artifact cards
- add sanitized synthetic fixtures and v0.7.0 docs/release notes; raw live Chrome/Crawlio captures stay ignored under private-research/ and are not included

## Validation
- npm test
- node --check for source, build script, generated exporters, and userscripts
- local live Crawlio/Chrome structural audit: ChatGPT data-message-author-role + CodeMirror/table/math counts; Gemini temporary chat user-query/model-response/message-content/code-block/table counts

## Notes
- headless-browser-interceptor was discovered but gated on the current Crawlio tier, so the audit used Crawlio Agent's available browser/network capture path
- GreasyFork publishing remains manual after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.7.0

* **New Features**
  * Added unified export engine supporting both ChatGPT and Gemini conversations
  * Introduced multi-format export: Markdown, HTML, and PDF
  * Enhanced content handling for code blocks, math notation, tables, and media elements
  * Improved provider detection and conversation extraction

* **Documentation**
  * Updated README with v0.7.0 features and version history
  * Expanded EXPORTER_GUIDE with format specifications and workflow guidance

* **Tests**
  * Added synthetic test fixtures with representative conversation structures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rashidazarang/chatgpt-chat-exporter/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->