### PR TITLE
Fix newlines in code blocks

### DIFF
--- a/chatgpt-markdown-exporter.user.js
+++ b/chatgpt-markdown-exporter.user.js
@@ -140,12 +140,6 @@
             }
         }
 
-        function getText(element) {
-            if (!element) return '';
-            const innerText = typeof element.innerText === 'string' ? element.innerText : '';
-            return (innerText || element.textContent || '').replace(/\u00a0/g, ' ').trim();
-        }
-
         function collectTextWithBreaks(node) {
             if (!node) return '';
 
@@ -166,16 +160,9 @@
             return before + Array.from(node.childNodes).map(collectTextWithBreaks).join('') + after;
         }
 
-        function getCodeText(element) {
+        function getText(element) {
             if (!element) return '';
-
-            if (typeof element.innerText === 'string' && element.innerText.trim()) {
-                return element.innerText.replace(/\u00a0/g, ' ').replace(/\n{3,}/g, '\n\n').trimEnd();
-            }
-
-            const clone = element.cloneNode(true);
-            queryAll(clone, 'br').forEach(br => br.replaceWith(clone.ownerDocument.createTextNode('\n')));
-            return collectTextWithBreaks(clone).replace(/\n{3,}/g, '\n\n').trimEnd();
+            return collectTextWithBreaks(element).replace(/\u00a0/g, ' ').trim();
         }
 
         function normalizeCodeText(value) {
@@ -183,6 +170,13 @@
                 .replace(/\r\n?/g, '\n')
                 .replace(/^\n+/, '')
                 .replace(/\n+$/, '');
+        }
+
+        function getCodeText(element) {
+            if (!element) return '';
+            const clone = element.cloneNode(true);
+            queryAll(clone, 'br').forEach(br => br.replaceWith(clone.ownerDocument.createTextNode('\n')));
+            return normalizeCodeText(collectTextWithBreaks(clone).replace(/\u00a0/g, ' '));
         }
 
         function markdownFenceFor(code) {
@@ -338,7 +332,7 @@
                 if (cmLines.length > 0) {
                     return {
                         lang: language,
-                        code: normalizeCodeText(cmLines.map(line => line.textContent || '').join('\n'))
+                        code: normalizeCodeText(cmLines.map(line => collectTextWithBreaks(line)).join('\n'))
                     };
                 }
 

--- a/chatgpt-markdown-exporter.user.js
+++ b/chatgpt-markdown-exporter.user.js
@@ -335,7 +335,7 @@
                 if (cmLines.length > 0) {
                     return {
                         lang: language,
-                        code: normalizeCodeText(cmLines.map(line => collectTextWithBreaks(line)).join('\n'))
+                        code: normalizeCodeText(cmLines.map(line => collectTextWithBreaks(line)).join(''))
                     };
                 }
 

--- a/chatgpt-markdown-exporter.user.js
+++ b/chatgpt-markdown-exporter.user.js
@@ -176,9 +176,12 @@
             if (!element) return '';
             const clone = element.cloneNode(true);
             queryAll(clone, 'br').forEach(br => br.replaceWith(clone.ownerDocument.createTextNode('\n')));
-            return normalizeCodeText(collectTextWithBreaks(clone).replace(/\u00a0/g, ' '));
+            return normalizeCodeText(
+                collectTextWithBreaks(clone)
+                    .replace(/\u00a0/g, ' ')
+                    .replace(/\n{3,}/g, '\n\n')
+            );
         }
-
         function markdownFenceFor(code) {
             const runs = String(code ?? '').match(/`{3,}/g) || [];
             const longest = runs.reduce((max, run) => Math.max(max, run.length), 2);


### PR DESCRIPTION
Exporting ChatGPT conversations to markdown did not preserve formatting; a lot of newline characters were being incorrectly stripped.
This PR fixes the issue specifically within generated code blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text extraction used for exported markdown and HTML to preserve line breaks more consistently.
  * Enhanced code-block export reliability, especially for content containing inline line breaks.
  * Updated code editor content extraction to match the improved break-aware text handling for more accurate exported output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->