### PR TITLE
Integrate exports into ChatGPT's native menus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ ChatGPT Chat Exporter is a browser-based tool for exporting ChatGPT and Google G
 
 - `exporter-markdown.js`, `exporter-html.js`, `exporter-pdf.js` — ChatGPT console scripts
 - `gemini-exporter-markdown.js` — Gemini console script
-- `chatgpt-markdown-exporter.user.js`, `chatgpt-pdf-exporter.user.js` — userscripts with an export button
+- `src/userscript-ui.js` — native ChatGPT conversation-menu and Share-menu integration
+- `chatgpt-markdown-exporter.user.js`, `chatgpt-pdf-exporter.user.js` — generated userscripts with Markdown and PDF menu actions
 
 **Never edit the generated files directly.** Change the engine or the build script, then run `npm run build`. `npm test` fails if the generated files are stale.
 

--- a/EXPORTER_GUIDE.md
+++ b/EXPORTER_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Available Exporters
 
-All shipped exporters are generated from the shared engine in `src/extraction-engine.js`. The console scripts remain self-contained and pasteable; the userscripts embed the same engine at build time.
+All shipped exporters are generated from the shared engine in `src/extraction-engine.js`. The console scripts remain self-contained and pasteable; the userscripts embed the same engine plus the native ChatGPT menu integration from `src/userscript-ui.js` at build time.
 
 ### 1. **exporter-markdown.js** - Markdown Export
 - **Output:** `.md` files
@@ -65,6 +65,7 @@ Use `gemini-exporter-markdown.js` from a conversation at `gemini.google.com/app`
 ## Notes
 
 - **PDF Exporter:** Downloads an HTML file with clear instructions. Open it and press Ctrl+P to save as PDF
+- **Userscripts:** Add Markdown and PDF actions beneath Share in conversation menus and replace the header Share dialog with Copy link, Markdown, and PDF actions
 - **HTML Exporter:** Basic HTML for web viewing. Can also be printed to PDF but without special formatting
 - **File Names:** All exporters now use the conversation title for better organization
 - **Math:** Markdown exports use common MathJax delimiters so compatible viewers can render equations

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ No install, no server, no account: everything runs locally in your browser.
 - 📄 Exports to **Markdown**, **HTML**, or **printable PDF**
 - 🆕 **Google Gemini** conversation export support
 - 🔒 **Private by default**: exports show the provider label without embedding your exact conversation URL
-- 🚀 Works directly from the browser console — or install as a one-click userscript
+- 🧩 Integrates with ChatGPT's native conversation and Share menus instead of adding floating controls
+- 🚀 Works directly from the browser console — or install as a userscript
 - 🛡️ One shared, tested extraction engine powers every exporter, with multiple selector fallbacks to survive UI changes
 
 ---
@@ -34,7 +35,7 @@ No install, no server, no account: everything runs locally in your browser.
    - [Violentmonkey](https://violentmonkey.github.io/) (Chrome, Firefox)
    - [Greasemonkey](https://addons.mozilla.org/en-US/firefox/addon/greasemonkey/) (Firefox)
 
-2. Install the script:
+2. Install either userscript. Both installers expose Markdown and PDF export actions, so existing installations keep working without needing both scripts:
 
    **From GreasyFork (Recommended):**
    - [Markdown Exporter](https://greasyfork.org/en/scripts/530789-chatgpt-chat-exporter-markdown)
@@ -44,7 +45,9 @@ No install, no server, no account: everything runs locally in your browser.
    - [Markdown Exporter](https://github.com/rashidazarang/chatgpt-chat-exporter/raw/master/chatgpt-markdown-exporter.user.js)
    - [PDF Exporter](https://github.com/rashidazarang/chatgpt-chat-exporter/raw/master/chatgpt-pdf-exporter.user.js)
 
-3. Open ChatGPT and click the **Export as Markdown** or **Export as PDF** button that appears in the corner of the page.
+3. Open a ChatGPT conversation, then either:
+   - Open the conversation's **•••** menu and choose **Export to Markdown** or **Export to PDF**.
+   - Click the header **Share** button and choose **Copy link**, **Export to Markdown**, or **Export to PDF**.
 
 ### Method 2: Browser Console
 
@@ -131,13 +134,14 @@ All exporters are generated from a single, tested engine:
 
 ```
 src/extraction-engine.js     ← canonical source (edit this)
+src/userscript-ui.js         ← native ChatGPT menu integration
 scripts/build-exporters.js   ← generates the files below
 ├── exporter-markdown.js         ChatGPT → Markdown (console)
 ├── exporter-html.js             ChatGPT → HTML (console)
 ├── exporter-pdf.js              ChatGPT → print-ready HTML (console)
 ├── gemini-exporter-markdown.js  Gemini → Markdown (console)
-├── chatgpt-markdown-exporter.user.js   userscript + export button
-└── chatgpt-pdf-exporter.user.js        userscript + export button
+├── chatgpt-markdown-exporter.user.js   userscript + native export menus
+└── chatgpt-pdf-exporter.user.js        userscript + native export menus
 ```
 
 The engine finds messages through a cascade of selector strategies (data attributes → ARIA → semantic HTML → content heuristics), so it keeps working across ChatGPT and Gemini UI revisions. Rich content — code, tables, math, links, media — is converted through a processing pipeline that protects verbatim regions (code, pre-wrap prompts) from whitespace cleanup.
@@ -150,7 +154,7 @@ npm run build   # regenerate all exporters from src/extraction-engine.js
 npm test        # verify generated files are current + run the jsdom test suite
 ```
 
-Never edit the generated exporter files directly — change `src/extraction-engine.js` (or the build script) and run `npm run build`.
+Never edit the generated exporter files directly — change `src/extraction-engine.js`, `src/userscript-ui.js`, or the build script and run `npm run build`.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) and [EXPORTER_GUIDE.md](EXPORTER_GUIDE.md) for details.
 
@@ -163,7 +167,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) and [EXPORTER_GUIDE.md](EXPORTER_GUIDE.md
 ## ❓ Troubleshooting
 
 - **"No messages found"** — the site's DOM may have changed. Update to the latest exporter version; if it persists, [open an issue](https://github.com/rashidazarang/chatgpt-chat-exporter/issues) with your browser and a description of the page.
-- **Export button doesn't appear** — confirm the userscript is enabled for `chatgpt.com` and reload the page.
+- **Export actions don't appear** — confirm the userscript is enabled for `chatgpt.com`, reload the page, and open a conversation's **•••** or header **Share** menu.
 - **Downloads blocked in the console** — some browsers require you to allow downloads/popups triggered from DevTools; the userscript method avoids this.
 
 ---

--- a/chatgpt-markdown-exporter.user.js
+++ b/chatgpt-markdown-exporter.user.js
@@ -2,7 +2,7 @@
 // @name         ChatGPT Chat Exporter - Markdown
 // @namespace    https://github.com/rashidazarang/chatgpt-chat-exporter
 // @version      0.7.2
-// @description  Export ChatGPT conversations to Markdown format
+// @description  Export ChatGPT conversations to Markdown or PDF from the native conversation menus
 // @author       rashidazarang
 // @match        https://chat.openai.com/*
 // @match        https://chatgpt.com/*
@@ -1186,59 +1186,255 @@
         };
     });
 
-    function runExport() {
-        globalThis.ChatExporterEngine.exportConversation({
-            provider: 'chatgpt',
-            format: 'markdown'
-        });
-    }
+    (function initChatExporterUi(root, factory) {
+        const ui = factory();
 
-    function addExportButton() {
-        if (document.querySelector('#chatgpt-export-markdown-btn')) return;
-
-        const button = document.createElement('button');
-        button.id = 'chatgpt-export-markdown-btn';
-        button.textContent = 'Export Markdown';
-        button.style.cssText = [
-            'position: fixed',
-            'bottom: 20px',
-            'right: 20px',
-            'padding: 10px 16px',
-            'background-color: #10a37f',
-            'color: white',
-            'border: none',
-            'border-radius: 5px',
-            'cursor: pointer',
-            'z-index: 10000',
-            'font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-            'font-size: 14px',
-            'font-weight: 600',
-            'box-shadow: 0 2px 4px rgba(0,0,0,0.2)'
-        ].join(';');
-
-        button.addEventListener('click', runExport);
-        button.addEventListener('mouseenter', () => {
-            button.style.backgroundColor = '#0d8f6e';
-        });
-        button.addEventListener('mouseleave', () => {
-            button.style.backgroundColor = '#10a37f';
-        });
-
-        document.body.appendChild(button);
-    }
-
-    function installButton() {
-        if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', () => setTimeout(addExportButton, 1000), { once: true });
-        } else {
-            setTimeout(addExportButton, 1000);
+        if (root) {
+            root.ChatExporterUi = ui;
         }
 
-        const observer = new MutationObserver(() => {
-            if (!document.querySelector('#chatgpt-export-markdown-btn')) addExportButton();
-        });
-        observer.observe(document.body, { childList: true, subtree: true });
-    }
+        if (typeof module !== 'undefined' && module.exports) {
+            module.exports = ui;
+        }
+    })(typeof globalThis !== 'undefined' ? globalThis : this, function buildChatExporterUi() {
+        'use strict';
 
-    installButton();
+        const MENU_ID = 'chat-exporter-share-menu';
+        const NATIVE_ITEM_ATTRIBUTE = 'data-chat-exporter-item';
+        const INSTALL_FLAG = '__CHAT_EXPORTER_UI_INSTALLED__';
+
+        const ICONS = {
+            link: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.1.1l2-2A5 5 0 0 0 12 4l-1.1 1.1"/><path d="M14 11a5 5 0 0 0-7.1-.1l-2 2A5 5 0 0 0 12 20l1.1-1.1"/></svg>',
+            markdown: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 6h16v12H4z"/><path d="M7 15V9l3 3 3-3v6"/><path d="m16 12 2 2 2-2"/></svg>',
+            pdf: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 2h9l5 5v15H6z"/><path d="M14 2v6h6"/><path d="M9 16h6M9 12h3"/></svg>'
+        };
+
+        function normalizeText(element) {
+            return String(element?.textContent || '').replace(/\s+/g, ' ').trim();
+        }
+
+        function isVisible(element) {
+            return Boolean(element && element.getClientRects().length);
+        }
+
+        function closeShareMenu(doc) {
+            doc.getElementById(MENU_ID)?.remove();
+        }
+
+        function createMenuItem(doc, label, icon, action) {
+            const item = doc.createElement('button');
+            item.type = 'button';
+            item.setAttribute('role', 'menuitem');
+            item.style.cssText = [
+                'display:flex', 'align-items:center', 'gap:10px', 'width:100%',
+                'padding:10px 12px', 'border:0', 'border-radius:8px',
+                'background:transparent', 'color:inherit', 'cursor:pointer',
+                'font:inherit', 'font-size:14px', 'text-align:left'
+            ].join(';');
+            item.innerHTML = `${icon}<span>${label}</span>`;
+            item.addEventListener('mouseenter', () => {
+                item.style.background = 'var(--surface-hover, rgba(127,127,127,.14))';
+            });
+            item.addEventListener('mouseleave', () => {
+                item.style.background = 'transparent';
+            });
+            item.addEventListener('click', event => {
+                event.preventDefault();
+                event.stopPropagation();
+                action(item);
+            });
+            return item;
+        }
+
+        function openShareMenu(doc, anchor, actions) {
+            closeShareMenu(doc);
+
+            const menu = doc.createElement('div');
+            menu.id = MENU_ID;
+            menu.setAttribute('role', 'menu');
+            menu.setAttribute('aria-label', 'Conversation export options');
+            menu.style.cssText = [
+                'position:fixed', 'z-index:100000', 'min-width:210px', 'padding:6px',
+                'border:1px solid var(--border-light, rgba(127,127,127,.22))',
+                'border-radius:12px', 'background:var(--main-surface-primary, #fff)',
+                'color:var(--text-primary, #111)',
+                'box-shadow:0 12px 32px rgba(0,0,0,.22)',
+                'font-family:ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
+            ].join(';');
+
+            menu.append(
+                createMenuItem(doc, 'Copy link', ICONS.link, async item => {
+                    try {
+                        await actions.copyLink();
+                        item.querySelector('span').textContent = 'Copied!';
+                        doc.defaultView.setTimeout(() => closeShareMenu(doc), 650);
+                    } catch (error) {
+                        console.error('[Chat Exporter] Could not copy the conversation link.', error);
+                        item.querySelector('span').textContent = 'Copy failed';
+                    }
+                }),
+                createMenuItem(doc, 'Export to Markdown', ICONS.markdown, () => {
+                    closeShareMenu(doc);
+                    actions.exportMarkdown();
+                }),
+                createMenuItem(doc, 'Export to PDF', ICONS.pdf, () => {
+                    closeShareMenu(doc);
+                    actions.exportPdf();
+                })
+            );
+
+            doc.body.appendChild(menu);
+            const anchorRect = anchor.getBoundingClientRect();
+            const menuRect = menu.getBoundingClientRect();
+            const view = doc.defaultView;
+            menu.style.top = `${Math.min(view.innerHeight - menuRect.height - 8, anchorRect.bottom + 8)}px`;
+            menu.style.left = `${Math.max(8, Math.min(view.innerWidth - menuRect.width - 8, anchorRect.right - menuRect.width))}px`;
+        }
+
+        function replaceShareLabel(doc, item, label) {
+            const walker = doc.createTreeWalker(item, doc.defaultView.NodeFilter.SHOW_TEXT);
+            let node;
+            while ((node = walker.nextNode())) {
+                if (node.nodeValue.trim() === 'Share') {
+                    node.nodeValue = node.nodeValue.replace('Share', label);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        function cloneNativeItem(doc, shareItem, label, format, action) {
+            const item = shareItem.cloneNode(true);
+            item.setAttribute(NATIVE_ITEM_ATTRIBUTE, format);
+            item.removeAttribute('data-state');
+            item.removeAttribute('id');
+            item.removeAttribute('aria-controls');
+            item.removeAttribute('aria-expanded');
+            item.removeAttribute('aria-haspopup');
+            item.querySelectorAll('[id]').forEach(element => element.removeAttribute('id'));
+            replaceShareLabel(doc, item, label);
+            item.addEventListener('click', event => {
+                event.preventDefault();
+                event.stopPropagation();
+                action();
+                doc.dispatchEvent(new doc.defaultView.KeyboardEvent('keydown', {
+                    key: 'Escape',
+                    bubbles: true
+                }));
+            });
+            return item;
+        }
+
+        function findMenus(root) {
+            const selector = '[role="menu"], [data-radix-menu-content]';
+            const menus = [];
+            if (root.matches?.(selector)) menus.push(root);
+            menus.push(...(root.querySelectorAll?.(selector) || []));
+            return menus;
+        }
+
+        function injectConversationMenuItems(doc, root, actions) {
+            const menus = findMenus(root).filter(isVisible);
+            for (const menu of menus) {
+                if (menu.querySelector(`[${NATIVE_ITEM_ATTRIBUTE}]`)) continue;
+
+                const candidates = Array.from(menu.querySelectorAll('button, [role="menuitem"], a, div'));
+                const shareItem = candidates.find(item => isVisible(item) && normalizeText(item) === 'Share');
+                if (!shareItem) continue;
+
+                const markdownItem = cloneNativeItem(
+                    doc,
+                    shareItem,
+                    'Export to Markdown',
+                    'markdown',
+                    actions.exportMarkdown
+                );
+                const pdfItem = cloneNativeItem(
+                    doc,
+                    shareItem,
+                    'Export to PDF',
+                    'pdf',
+                    actions.exportPdf
+                );
+                shareItem.insertAdjacentElement('afterend', pdfItem);
+                shareItem.insertAdjacentElement('afterend', markdownItem);
+            }
+        }
+
+        function isHeaderShareButton(element) {
+            const button = element?.closest?.('button');
+            if (!button || normalizeText(button) !== 'Share') return null;
+            if (button.closest('[role="menu"], [data-radix-menu-content]')) return null;
+            return button;
+        }
+
+        function install(options = {}) {
+            const doc = options.document || (typeof document !== 'undefined' ? document : null);
+            const engine = options.engine || globalThis.ChatExporterEngine;
+            if (!doc || !engine || doc.defaultView[INSTALL_FLAG]) return false;
+
+            doc.defaultView[INSTALL_FLAG] = true;
+            const actions = {
+                copyLink: options.copyLink || (() => doc.defaultView.navigator.clipboard.writeText(doc.defaultView.location.href)),
+                exportMarkdown: options.exportMarkdown || (() => engine.exportConversation({ provider: 'chatgpt', format: 'markdown' })),
+                exportPdf: options.exportPdf || (() => engine.exportConversation({ provider: 'chatgpt', format: 'pdf' }))
+            };
+
+            doc.addEventListener('click', event => {
+                const shareButton = isHeaderShareButton(event.target);
+                if (shareButton) {
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
+                    doc.getElementById(MENU_ID)
+                        ? closeShareMenu(doc)
+                        : openShareMenu(doc, shareButton, actions);
+                    return;
+                }
+                if (!event.target.closest?.(`#${MENU_ID}`)) closeShareMenu(doc);
+            }, true);
+
+            doc.addEventListener('keydown', event => {
+                if (event.key === 'Escape') closeShareMenu(doc);
+            });
+
+            const start = () => {
+                injectConversationMenuItems(doc, doc, actions);
+                const observer = new doc.defaultView.MutationObserver(records => {
+                    for (const record of records) {
+                        if (record.type === 'attributes') {
+                            injectConversationMenuItems(doc, record.target, actions);
+                        }
+                        for (const node of record.addedNodes) {
+                            if (node.nodeType === doc.defaultView.Node.ELEMENT_NODE) {
+                                injectConversationMenuItems(doc, node, actions);
+                            }
+                        }
+                    }
+                });
+                observer.observe(doc.documentElement, {
+                    attributes: true,
+                    attributeFilter: ['class', 'hidden', 'style', 'data-state'],
+                    childList: true,
+                    subtree: true
+                });
+            };
+
+            if (doc.readyState === 'loading') {
+                doc.addEventListener('DOMContentLoaded', start, { once: true });
+            } else {
+                start();
+            }
+            return true;
+        }
+
+        return {
+            install,
+            internals: {
+                injectConversationMenuItems,
+                isHeaderShareButton
+            }
+        };
+    });
+
+    globalThis.ChatExporterUi.install({ engine: globalThis.ChatExporterEngine });
 })();

--- a/chatgpt-pdf-exporter.user.js
+++ b/chatgpt-pdf-exporter.user.js
@@ -2,7 +2,7 @@
 // @name         ChatGPT Chat Exporter - PDF
 // @namespace    https://github.com/rashidazarang/chatgpt-chat-exporter
 // @version      0.7.2
-// @description  Export ChatGPT conversations to PDF-ready HTML format
+// @description  Export ChatGPT conversations to Markdown or PDF from the native conversation menus
 // @author       rashidazarang
 // @match        https://chat.openai.com/*
 // @match        https://chatgpt.com/*
@@ -1186,59 +1186,255 @@
         };
     });
 
-    function runExport() {
-        globalThis.ChatExporterEngine.exportConversation({
-            provider: 'chatgpt',
-            format: 'pdf'
-        });
-    }
+    (function initChatExporterUi(root, factory) {
+        const ui = factory();
 
-    function addExportButton() {
-        if (document.querySelector('#chatgpt-export-pdf-btn')) return;
-
-        const button = document.createElement('button');
-        button.id = 'chatgpt-export-pdf-btn';
-        button.textContent = 'Export PDF';
-        button.style.cssText = [
-            'position: fixed',
-            'bottom: 20px',
-            'right: 170px',
-            'padding: 10px 16px',
-            'background-color: #3498db',
-            'color: white',
-            'border: none',
-            'border-radius: 5px',
-            'cursor: pointer',
-            'z-index: 10000',
-            'font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-            'font-size: 14px',
-            'font-weight: 600',
-            'box-shadow: 0 2px 4px rgba(0,0,0,0.2)'
-        ].join(';');
-
-        button.addEventListener('click', runExport);
-        button.addEventListener('mouseenter', () => {
-            button.style.backgroundColor = '#2c7fb8';
-        });
-        button.addEventListener('mouseleave', () => {
-            button.style.backgroundColor = '#3498db';
-        });
-
-        document.body.appendChild(button);
-    }
-
-    function installButton() {
-        if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', () => setTimeout(addExportButton, 1000), { once: true });
-        } else {
-            setTimeout(addExportButton, 1000);
+        if (root) {
+            root.ChatExporterUi = ui;
         }
 
-        const observer = new MutationObserver(() => {
-            if (!document.querySelector('#chatgpt-export-pdf-btn')) addExportButton();
-        });
-        observer.observe(document.body, { childList: true, subtree: true });
-    }
+        if (typeof module !== 'undefined' && module.exports) {
+            module.exports = ui;
+        }
+    })(typeof globalThis !== 'undefined' ? globalThis : this, function buildChatExporterUi() {
+        'use strict';
 
-    installButton();
+        const MENU_ID = 'chat-exporter-share-menu';
+        const NATIVE_ITEM_ATTRIBUTE = 'data-chat-exporter-item';
+        const INSTALL_FLAG = '__CHAT_EXPORTER_UI_INSTALLED__';
+
+        const ICONS = {
+            link: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.1.1l2-2A5 5 0 0 0 12 4l-1.1 1.1"/><path d="M14 11a5 5 0 0 0-7.1-.1l-2 2A5 5 0 0 0 12 20l1.1-1.1"/></svg>',
+            markdown: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 6h16v12H4z"/><path d="M7 15V9l3 3 3-3v6"/><path d="m16 12 2 2 2-2"/></svg>',
+            pdf: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 2h9l5 5v15H6z"/><path d="M14 2v6h6"/><path d="M9 16h6M9 12h3"/></svg>'
+        };
+
+        function normalizeText(element) {
+            return String(element?.textContent || '').replace(/\s+/g, ' ').trim();
+        }
+
+        function isVisible(element) {
+            return Boolean(element && element.getClientRects().length);
+        }
+
+        function closeShareMenu(doc) {
+            doc.getElementById(MENU_ID)?.remove();
+        }
+
+        function createMenuItem(doc, label, icon, action) {
+            const item = doc.createElement('button');
+            item.type = 'button';
+            item.setAttribute('role', 'menuitem');
+            item.style.cssText = [
+                'display:flex', 'align-items:center', 'gap:10px', 'width:100%',
+                'padding:10px 12px', 'border:0', 'border-radius:8px',
+                'background:transparent', 'color:inherit', 'cursor:pointer',
+                'font:inherit', 'font-size:14px', 'text-align:left'
+            ].join(';');
+            item.innerHTML = `${icon}<span>${label}</span>`;
+            item.addEventListener('mouseenter', () => {
+                item.style.background = 'var(--surface-hover, rgba(127,127,127,.14))';
+            });
+            item.addEventListener('mouseleave', () => {
+                item.style.background = 'transparent';
+            });
+            item.addEventListener('click', event => {
+                event.preventDefault();
+                event.stopPropagation();
+                action(item);
+            });
+            return item;
+        }
+
+        function openShareMenu(doc, anchor, actions) {
+            closeShareMenu(doc);
+
+            const menu = doc.createElement('div');
+            menu.id = MENU_ID;
+            menu.setAttribute('role', 'menu');
+            menu.setAttribute('aria-label', 'Conversation export options');
+            menu.style.cssText = [
+                'position:fixed', 'z-index:100000', 'min-width:210px', 'padding:6px',
+                'border:1px solid var(--border-light, rgba(127,127,127,.22))',
+                'border-radius:12px', 'background:var(--main-surface-primary, #fff)',
+                'color:var(--text-primary, #111)',
+                'box-shadow:0 12px 32px rgba(0,0,0,.22)',
+                'font-family:ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
+            ].join(';');
+
+            menu.append(
+                createMenuItem(doc, 'Copy link', ICONS.link, async item => {
+                    try {
+                        await actions.copyLink();
+                        item.querySelector('span').textContent = 'Copied!';
+                        doc.defaultView.setTimeout(() => closeShareMenu(doc), 650);
+                    } catch (error) {
+                        console.error('[Chat Exporter] Could not copy the conversation link.', error);
+                        item.querySelector('span').textContent = 'Copy failed';
+                    }
+                }),
+                createMenuItem(doc, 'Export to Markdown', ICONS.markdown, () => {
+                    closeShareMenu(doc);
+                    actions.exportMarkdown();
+                }),
+                createMenuItem(doc, 'Export to PDF', ICONS.pdf, () => {
+                    closeShareMenu(doc);
+                    actions.exportPdf();
+                })
+            );
+
+            doc.body.appendChild(menu);
+            const anchorRect = anchor.getBoundingClientRect();
+            const menuRect = menu.getBoundingClientRect();
+            const view = doc.defaultView;
+            menu.style.top = `${Math.min(view.innerHeight - menuRect.height - 8, anchorRect.bottom + 8)}px`;
+            menu.style.left = `${Math.max(8, Math.min(view.innerWidth - menuRect.width - 8, anchorRect.right - menuRect.width))}px`;
+        }
+
+        function replaceShareLabel(doc, item, label) {
+            const walker = doc.createTreeWalker(item, doc.defaultView.NodeFilter.SHOW_TEXT);
+            let node;
+            while ((node = walker.nextNode())) {
+                if (node.nodeValue.trim() === 'Share') {
+                    node.nodeValue = node.nodeValue.replace('Share', label);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        function cloneNativeItem(doc, shareItem, label, format, action) {
+            const item = shareItem.cloneNode(true);
+            item.setAttribute(NATIVE_ITEM_ATTRIBUTE, format);
+            item.removeAttribute('data-state');
+            item.removeAttribute('id');
+            item.removeAttribute('aria-controls');
+            item.removeAttribute('aria-expanded');
+            item.removeAttribute('aria-haspopup');
+            item.querySelectorAll('[id]').forEach(element => element.removeAttribute('id'));
+            replaceShareLabel(doc, item, label);
+            item.addEventListener('click', event => {
+                event.preventDefault();
+                event.stopPropagation();
+                action();
+                doc.dispatchEvent(new doc.defaultView.KeyboardEvent('keydown', {
+                    key: 'Escape',
+                    bubbles: true
+                }));
+            });
+            return item;
+        }
+
+        function findMenus(root) {
+            const selector = '[role="menu"], [data-radix-menu-content]';
+            const menus = [];
+            if (root.matches?.(selector)) menus.push(root);
+            menus.push(...(root.querySelectorAll?.(selector) || []));
+            return menus;
+        }
+
+        function injectConversationMenuItems(doc, root, actions) {
+            const menus = findMenus(root).filter(isVisible);
+            for (const menu of menus) {
+                if (menu.querySelector(`[${NATIVE_ITEM_ATTRIBUTE}]`)) continue;
+
+                const candidates = Array.from(menu.querySelectorAll('button, [role="menuitem"], a, div'));
+                const shareItem = candidates.find(item => isVisible(item) && normalizeText(item) === 'Share');
+                if (!shareItem) continue;
+
+                const markdownItem = cloneNativeItem(
+                    doc,
+                    shareItem,
+                    'Export to Markdown',
+                    'markdown',
+                    actions.exportMarkdown
+                );
+                const pdfItem = cloneNativeItem(
+                    doc,
+                    shareItem,
+                    'Export to PDF',
+                    'pdf',
+                    actions.exportPdf
+                );
+                shareItem.insertAdjacentElement('afterend', pdfItem);
+                shareItem.insertAdjacentElement('afterend', markdownItem);
+            }
+        }
+
+        function isHeaderShareButton(element) {
+            const button = element?.closest?.('button');
+            if (!button || normalizeText(button) !== 'Share') return null;
+            if (button.closest('[role="menu"], [data-radix-menu-content]')) return null;
+            return button;
+        }
+
+        function install(options = {}) {
+            const doc = options.document || (typeof document !== 'undefined' ? document : null);
+            const engine = options.engine || globalThis.ChatExporterEngine;
+            if (!doc || !engine || doc.defaultView[INSTALL_FLAG]) return false;
+
+            doc.defaultView[INSTALL_FLAG] = true;
+            const actions = {
+                copyLink: options.copyLink || (() => doc.defaultView.navigator.clipboard.writeText(doc.defaultView.location.href)),
+                exportMarkdown: options.exportMarkdown || (() => engine.exportConversation({ provider: 'chatgpt', format: 'markdown' })),
+                exportPdf: options.exportPdf || (() => engine.exportConversation({ provider: 'chatgpt', format: 'pdf' }))
+            };
+
+            doc.addEventListener('click', event => {
+                const shareButton = isHeaderShareButton(event.target);
+                if (shareButton) {
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
+                    doc.getElementById(MENU_ID)
+                        ? closeShareMenu(doc)
+                        : openShareMenu(doc, shareButton, actions);
+                    return;
+                }
+                if (!event.target.closest?.(`#${MENU_ID}`)) closeShareMenu(doc);
+            }, true);
+
+            doc.addEventListener('keydown', event => {
+                if (event.key === 'Escape') closeShareMenu(doc);
+            });
+
+            const start = () => {
+                injectConversationMenuItems(doc, doc, actions);
+                const observer = new doc.defaultView.MutationObserver(records => {
+                    for (const record of records) {
+                        if (record.type === 'attributes') {
+                            injectConversationMenuItems(doc, record.target, actions);
+                        }
+                        for (const node of record.addedNodes) {
+                            if (node.nodeType === doc.defaultView.Node.ELEMENT_NODE) {
+                                injectConversationMenuItems(doc, node, actions);
+                            }
+                        }
+                    }
+                });
+                observer.observe(doc.documentElement, {
+                    attributes: true,
+                    attributeFilter: ['class', 'hidden', 'style', 'data-state'],
+                    childList: true,
+                    subtree: true
+                });
+            };
+
+            if (doc.readyState === 'loading') {
+                doc.addEventListener('DOMContentLoaded', start, { once: true });
+            } else {
+                start();
+            }
+            return true;
+        }
+
+        return {
+            install,
+            internals: {
+                injectConversationMenuItems,
+                isHeaderShareButton
+            }
+        };
+    });
+
+    globalThis.ChatExporterUi.install({ engine: globalThis.ChatExporterEngine });
 })();

--- a/scripts/build-exporters.js
+++ b/scripts/build-exporters.js
@@ -3,6 +3,7 @@ const path = require('node:path');
 
 const repoRoot = path.resolve(__dirname, '..');
 const engineSource = fs.readFileSync(path.join(repoRoot, 'src', 'extraction-engine.js'), 'utf8').trim();
+const userscriptUiSource = fs.readFileSync(path.join(repoRoot, 'src', 'userscript-ui.js'), 'utf8').trim();
 const { version } = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
 const checkOnly = process.argv.includes('--check');
 
@@ -43,67 +44,15 @@ function userscriptHeader(name, version, description) {
 `;
 }
 
-function userscript(provider, format, buttonId, buttonText, right, color, hoverColor, name, description) {
+function userscript(name, description) {
     return `${userscriptHeader(name, version, description)}(() => {
     'use strict';
 
 ${indent(engineSource, 4)}
 
-    function runExport() {
-        globalThis.ChatExporterEngine.exportConversation({
-            provider: '${provider}',
-            format: '${format}'
-        });
-    }
+${indent(userscriptUiSource, 4)}
 
-    function addExportButton() {
-        if (document.querySelector('#${buttonId}')) return;
-
-        const button = document.createElement('button');
-        button.id = '${buttonId}';
-        button.textContent = '${buttonText}';
-        button.style.cssText = [
-            'position: fixed',
-            'bottom: 20px',
-            'right: ${right}',
-            'padding: 10px 16px',
-            'background-color: ${color}',
-            'color: white',
-            'border: none',
-            'border-radius: 5px',
-            'cursor: pointer',
-            'z-index: 10000',
-            'font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-            'font-size: 14px',
-            'font-weight: 600',
-            'box-shadow: 0 2px 4px rgba(0,0,0,0.2)'
-        ].join(';');
-
-        button.addEventListener('click', runExport);
-        button.addEventListener('mouseenter', () => {
-            button.style.backgroundColor = '${hoverColor}';
-        });
-        button.addEventListener('mouseleave', () => {
-            button.style.backgroundColor = '${color}';
-        });
-
-        document.body.appendChild(button);
-    }
-
-    function installButton() {
-        if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', () => setTimeout(addExportButton, 1000), { once: true });
-        } else {
-            setTimeout(addExportButton, 1000);
-        }
-
-        const observer = new MutationObserver(() => {
-            if (!document.querySelector('#${buttonId}')) addExportButton();
-        });
-        observer.observe(document.body, { childList: true, subtree: true });
-    }
-
-    installButton();
+    globalThis.ChatExporterUi.install({ engine: globalThis.ChatExporterEngine });
 })();
 `;
 }
@@ -119,26 +68,12 @@ const outputs = new Map([
     ['exporter-pdf.js', runner('chatgpt', 'pdf')],
     ['gemini-exporter-markdown.js', runner('gemini', 'markdown')],
     ['chatgpt-markdown-exporter.user.js', userscript(
-        'chatgpt',
-        'markdown',
-        'chatgpt-export-markdown-btn',
-        'Export Markdown',
-        '20px',
-        '#10a37f',
-        '#0d8f6e',
         'ChatGPT Chat Exporter - Markdown',
-        'Export ChatGPT conversations to Markdown format'
+        'Export ChatGPT conversations to Markdown or PDF from the native conversation menus'
     )],
     ['chatgpt-pdf-exporter.user.js', userscript(
-        'chatgpt',
-        'pdf',
-        'chatgpt-export-pdf-btn',
-        'Export PDF',
-        '170px',
-        '#3498db',
-        '#2c7fb8',
         'ChatGPT Chat Exporter - PDF',
-        'Export ChatGPT conversations to PDF-ready HTML format'
+        'Export ChatGPT conversations to Markdown or PDF from the native conversation menus'
     )]
 ]);
 

--- a/src/userscript-ui.js
+++ b/src/userscript-ui.js
@@ -1,0 +1,249 @@
+(function initChatExporterUi(root, factory) {
+    const ui = factory();
+
+    if (root) {
+        root.ChatExporterUi = ui;
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = ui;
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function buildChatExporterUi() {
+    'use strict';
+
+    const MENU_ID = 'chat-exporter-share-menu';
+    const NATIVE_ITEM_ATTRIBUTE = 'data-chat-exporter-item';
+    const INSTALL_FLAG = '__CHAT_EXPORTER_UI_INSTALLED__';
+
+    const ICONS = {
+        link: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.1.1l2-2A5 5 0 0 0 12 4l-1.1 1.1"/><path d="M14 11a5 5 0 0 0-7.1-.1l-2 2A5 5 0 0 0 12 20l1.1-1.1"/></svg>',
+        markdown: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 6h16v12H4z"/><path d="M7 15V9l3 3 3-3v6"/><path d="m16 12 2 2 2-2"/></svg>',
+        pdf: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 2h9l5 5v15H6z"/><path d="M14 2v6h6"/><path d="M9 16h6M9 12h3"/></svg>'
+    };
+
+    function normalizeText(element) {
+        return String(element?.textContent || '').replace(/\s+/g, ' ').trim();
+    }
+
+    function isVisible(element) {
+        return Boolean(element && element.getClientRects().length);
+    }
+
+    function closeShareMenu(doc) {
+        doc.getElementById(MENU_ID)?.remove();
+    }
+
+    function createMenuItem(doc, label, icon, action) {
+        const item = doc.createElement('button');
+        item.type = 'button';
+        item.setAttribute('role', 'menuitem');
+        item.style.cssText = [
+            'display:flex', 'align-items:center', 'gap:10px', 'width:100%',
+            'padding:10px 12px', 'border:0', 'border-radius:8px',
+            'background:transparent', 'color:inherit', 'cursor:pointer',
+            'font:inherit', 'font-size:14px', 'text-align:left'
+        ].join(';');
+        item.innerHTML = `${icon}<span>${label}</span>`;
+        item.addEventListener('mouseenter', () => {
+            item.style.background = 'var(--surface-hover, rgba(127,127,127,.14))';
+        });
+        item.addEventListener('mouseleave', () => {
+            item.style.background = 'transparent';
+        });
+        item.addEventListener('click', event => {
+            event.preventDefault();
+            event.stopPropagation();
+            action(item);
+        });
+        return item;
+    }
+
+    function openShareMenu(doc, anchor, actions) {
+        closeShareMenu(doc);
+
+        const menu = doc.createElement('div');
+        menu.id = MENU_ID;
+        menu.setAttribute('role', 'menu');
+        menu.setAttribute('aria-label', 'Conversation export options');
+        menu.style.cssText = [
+            'position:fixed', 'z-index:100000', 'min-width:210px', 'padding:6px',
+            'border:1px solid var(--border-light, rgba(127,127,127,.22))',
+            'border-radius:12px', 'background:var(--main-surface-primary, #fff)',
+            'color:var(--text-primary, #111)',
+            'box-shadow:0 12px 32px rgba(0,0,0,.22)',
+            'font-family:ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
+        ].join(';');
+
+        menu.append(
+            createMenuItem(doc, 'Copy link', ICONS.link, async item => {
+                try {
+                    await actions.copyLink();
+                    item.querySelector('span').textContent = 'Copied!';
+                    doc.defaultView.setTimeout(() => closeShareMenu(doc), 650);
+                } catch (error) {
+                    console.error('[Chat Exporter] Could not copy the conversation link.', error);
+                    item.querySelector('span').textContent = 'Copy failed';
+                }
+            }),
+            createMenuItem(doc, 'Export to Markdown', ICONS.markdown, () => {
+                closeShareMenu(doc);
+                actions.exportMarkdown();
+            }),
+            createMenuItem(doc, 'Export to PDF', ICONS.pdf, () => {
+                closeShareMenu(doc);
+                actions.exportPdf();
+            })
+        );
+
+        doc.body.appendChild(menu);
+        const anchorRect = anchor.getBoundingClientRect();
+        const menuRect = menu.getBoundingClientRect();
+        const view = doc.defaultView;
+        menu.style.top = `${Math.min(view.innerHeight - menuRect.height - 8, anchorRect.bottom + 8)}px`;
+        menu.style.left = `${Math.max(8, Math.min(view.innerWidth - menuRect.width - 8, anchorRect.right - menuRect.width))}px`;
+    }
+
+    function replaceShareLabel(doc, item, label) {
+        const walker = doc.createTreeWalker(item, doc.defaultView.NodeFilter.SHOW_TEXT);
+        let node;
+        while ((node = walker.nextNode())) {
+            if (node.nodeValue.trim() === 'Share') {
+                node.nodeValue = node.nodeValue.replace('Share', label);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function cloneNativeItem(doc, shareItem, label, format, action) {
+        const item = shareItem.cloneNode(true);
+        item.setAttribute(NATIVE_ITEM_ATTRIBUTE, format);
+        item.removeAttribute('data-state');
+        item.removeAttribute('id');
+        item.removeAttribute('aria-controls');
+        item.removeAttribute('aria-expanded');
+        item.removeAttribute('aria-haspopup');
+        item.querySelectorAll('[id]').forEach(element => element.removeAttribute('id'));
+        replaceShareLabel(doc, item, label);
+        item.addEventListener('click', event => {
+            event.preventDefault();
+            event.stopPropagation();
+            action();
+            doc.dispatchEvent(new doc.defaultView.KeyboardEvent('keydown', {
+                key: 'Escape',
+                bubbles: true
+            }));
+        });
+        return item;
+    }
+
+    function findMenus(root) {
+        const selector = '[role="menu"], [data-radix-menu-content]';
+        const menus = [];
+        if (root.matches?.(selector)) menus.push(root);
+        menus.push(...(root.querySelectorAll?.(selector) || []));
+        return menus;
+    }
+
+    function injectConversationMenuItems(doc, root, actions) {
+        const menus = findMenus(root).filter(isVisible);
+        for (const menu of menus) {
+            if (menu.querySelector(`[${NATIVE_ITEM_ATTRIBUTE}]`)) continue;
+
+            const candidates = Array.from(menu.querySelectorAll('button, [role="menuitem"], a, div'));
+            const shareItem = candidates.find(item => isVisible(item) && normalizeText(item) === 'Share');
+            if (!shareItem) continue;
+
+            const markdownItem = cloneNativeItem(
+                doc,
+                shareItem,
+                'Export to Markdown',
+                'markdown',
+                actions.exportMarkdown
+            );
+            const pdfItem = cloneNativeItem(
+                doc,
+                shareItem,
+                'Export to PDF',
+                'pdf',
+                actions.exportPdf
+            );
+            shareItem.insertAdjacentElement('afterend', pdfItem);
+            shareItem.insertAdjacentElement('afterend', markdownItem);
+        }
+    }
+
+    function isHeaderShareButton(element) {
+        const button = element?.closest?.('button');
+        if (!button || normalizeText(button) !== 'Share') return null;
+        if (button.closest('[role="menu"], [data-radix-menu-content]')) return null;
+        return button;
+    }
+
+    function install(options = {}) {
+        const doc = options.document || (typeof document !== 'undefined' ? document : null);
+        const engine = options.engine || globalThis.ChatExporterEngine;
+        if (!doc || !engine || doc.defaultView[INSTALL_FLAG]) return false;
+
+        doc.defaultView[INSTALL_FLAG] = true;
+        const actions = {
+            copyLink: options.copyLink || (() => doc.defaultView.navigator.clipboard.writeText(doc.defaultView.location.href)),
+            exportMarkdown: options.exportMarkdown || (() => engine.exportConversation({ provider: 'chatgpt', format: 'markdown' })),
+            exportPdf: options.exportPdf || (() => engine.exportConversation({ provider: 'chatgpt', format: 'pdf' }))
+        };
+
+        doc.addEventListener('click', event => {
+            const shareButton = isHeaderShareButton(event.target);
+            if (shareButton) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                doc.getElementById(MENU_ID)
+                    ? closeShareMenu(doc)
+                    : openShareMenu(doc, shareButton, actions);
+                return;
+            }
+            if (!event.target.closest?.(`#${MENU_ID}`)) closeShareMenu(doc);
+        }, true);
+
+        doc.addEventListener('keydown', event => {
+            if (event.key === 'Escape') closeShareMenu(doc);
+        });
+
+        const start = () => {
+            injectConversationMenuItems(doc, doc, actions);
+            const observer = new doc.defaultView.MutationObserver(records => {
+                for (const record of records) {
+                    if (record.type === 'attributes') {
+                        injectConversationMenuItems(doc, record.target, actions);
+                    }
+                    for (const node of record.addedNodes) {
+                        if (node.nodeType === doc.defaultView.Node.ELEMENT_NODE) {
+                            injectConversationMenuItems(doc, node, actions);
+                        }
+                    }
+                }
+            });
+            observer.observe(doc.documentElement, {
+                attributes: true,
+                attributeFilter: ['class', 'hidden', 'style', 'data-state'],
+                childList: true,
+                subtree: true
+            });
+        };
+
+        if (doc.readyState === 'loading') {
+            doc.addEventListener('DOMContentLoaded', start, { once: true });
+        } else {
+            start();
+        }
+        return true;
+    }
+
+    return {
+        install,
+        internals: {
+            injectConversationMenuItems,
+            isHeaderShareButton
+        }
+    };
+});

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -4,6 +4,7 @@ const path = require('node:path');
 const test = require('node:test');
 const { JSDOM } = require('jsdom');
 const engine = require('../src/extraction-engine.js');
+const userscriptUi = require('../src/userscript-ui.js');
 
 const repoRoot = path.resolve(__dirname, '..');
 
@@ -183,6 +184,101 @@ async function runExporter(filename, html, url = 'https://chatgpt.com/c/test-fix
         content: await latest.blob.text()
     };
 }
+
+function installUserscriptUi() {
+    const dom = new JSDOM(`<!DOCTYPE html>
+<html>
+<body>
+    <header><button id="header-share"><span>Share</span></button></header>
+    <div id="conversation-menu" role="menu">
+        <button role="menuitem"><svg aria-hidden="true"></svg><span>Share</span></button>
+        <button role="menuitem"><span>Rename</span></button>
+    </div>
+</body>
+</html>`, {
+        url: 'https://chatgpt.com/c/ui-fixture',
+        pretendToBeVisual: true
+    });
+    const { window } = dom;
+    window.HTMLElement.prototype.getClientRects = () => [{ width: 100, height: 30 }];
+    window.HTMLElement.prototype.getBoundingClientRect = () => ({
+        top: 10,
+        right: 200,
+        bottom: 40,
+        left: 100,
+        width: 100,
+        height: 30
+    });
+
+    const calls = [];
+    userscriptUi.install({
+        document: window.document,
+        engine: {},
+        copyLink: async () => calls.push('copy'),
+        exportMarkdown: () => calls.push('markdown'),
+        exportPdf: () => calls.push('pdf')
+    });
+    window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
+    return { dom, window, calls };
+}
+
+test('userscript integrates Markdown and PDF actions into ChatGPT conversation menus', () => {
+    const { window, calls } = installUserscriptUi();
+    const menu = window.document.querySelector('#conversation-menu');
+    const labels = Array.from(menu.querySelectorAll('[role="menuitem"]')).map(item => item.textContent.trim());
+
+    assert.deepEqual(labels, ['Share', 'Export to Markdown', 'Export to PDF', 'Rename']);
+    assert.equal(window.document.querySelector('#chatgpt-export-markdown-btn'), null);
+    assert.equal(window.document.querySelector('#chatgpt-export-pdf-btn'), null);
+
+    menu.querySelector('[data-chat-exporter-item="markdown"]').click();
+    menu.querySelector('[data-chat-exporter-item="pdf"]').click();
+    assert.deepEqual(calls, ['markdown', 'pdf']);
+});
+
+test('userscript injects into a previously mounted menu when ChatGPT reveals it', async () => {
+    const { window } = installUserscriptUi();
+    const menu = window.document.createElement('div');
+    menu.id = 'lazy-conversation-menu';
+    menu.setAttribute('role', 'menu');
+    menu.hidden = true;
+    menu.innerHTML = '<button id="native-share" role="menuitem" aria-haspopup="dialog" aria-controls="share-dialog"><span>Share</span></button>';
+    menu.getClientRects = () => menu.hidden ? [] : [{ width: 100, height: 30 }];
+    window.document.body.appendChild(menu);
+    await new Promise(resolve => window.setTimeout(resolve, 0));
+
+    assert.equal(menu.querySelector('[data-chat-exporter-item]'), null);
+    menu.hidden = false;
+    await new Promise(resolve => window.setTimeout(resolve, 0));
+
+    const exportItems = Array.from(menu.querySelectorAll('[data-chat-exporter-item]'));
+    assert.deepEqual(exportItems.map(item => item.textContent), ['Export to Markdown', 'Export to PDF']);
+    assert.ok(exportItems.every(item => !item.id && !item.hasAttribute('aria-controls') && !item.hasAttribute('aria-haspopup')));
+    assert.equal(window.document.querySelectorAll('#native-share').length, 1);
+});
+
+test('userscript replaces the header Share dialog with copy, Markdown, and PDF actions', async () => {
+    const { window, calls } = installUserscriptUi();
+    window.document.querySelector('#header-share').click();
+
+    const menu = window.document.querySelector('#chat-exporter-share-menu');
+    assert.ok(menu);
+    const items = Array.from(menu.querySelectorAll('[role="menuitem"]'));
+    assert.deepEqual(items.map(item => item.textContent), ['Copy link', 'Export to Markdown', 'Export to PDF']);
+
+    items[0].click();
+    await Promise.resolve();
+    assert.deepEqual(calls, ['copy']);
+
+    window.document.body.click();
+    window.document.querySelector('#header-share').click();
+    window.document.querySelector('#chat-exporter-share-menu [role="menuitem"]:nth-child(2)').click();
+    assert.deepEqual(calls, ['copy', 'markdown']);
+
+    window.document.querySelector('#header-share').click();
+    window.document.querySelector('#chat-exporter-share-menu [role="menuitem"]:nth-child(3)').click();
+    assert.deepEqual(calls, ['copy', 'markdown', 'pdf']);
+});
 
 test('ChatGPT markdown exporter preserves CodeMirror code, MathJax, tables, links, and media', async () => {
     const { content } = await runExporter('exporter-markdown.js', chatGptFixture());


### PR DESCRIPTION
## Summary

- replace the floating userscript buttons with export actions inside ChatGPT's native conversation menus
- turn the header Share control into a compact menu with Copy link, Export to Markdown, and Export to PDF
- keep both historical userscript installers compatible while sharing one canonical UI implementation
- document the new workflow and add regression coverage for dynamic and reused ChatGPT menu nodes

## Why

The fixed-position controls feel separate from ChatGPT and can overlap page content. ChatGPT already exposes conversation actions through its three-dot and Share menus, so export belongs alongside those native actions.

Both Markdown and PDF remain available from either existing userscript installer. A per-window guard prevents duplicate handlers if both legacy scripts are installed.

## Implementation

- add `src/userscript-ui.js` as the canonical native-menu integration
- embed that module into both generated ChatGPT userscripts from `scripts/build-exporters.js`
- clone native menu items while stripping IDs and popup-specific ARIA attributes
- observe both added nodes and visibility/state changes because ChatGPT can reuse hidden menu nodes
- preserve the existing extraction engine and generated-artifact workflow

## Validation

- `npm run build`
- `npm test` — 14/14 passing
- `git diff --check`

The tests cover native conversation-menu injection, header Share replacement, Copy link, Markdown and PDF actions, hidden-menu reuse, clone sanitization, and generated-file parity.
