### PR TITLE
Fix whitespace loss from non-citation references

### DIFF
--- a/chatgpt-markdown-exporter.user.js
+++ b/chatgpt-markdown-exporter.user.js
@@ -1475,7 +1475,13 @@
             if (Array.isArray(references)) {
                 references.forEach(reference => {
                     const marker = reference?.matched_text;
-                    if (!marker || !result.includes(marker)) return;
+                    // content_references is not limited to web citations. Current
+                    // ChatGPT payloads can include bookkeeping entries whose
+                    // matched_text is a single space and which carry no URL. If we
+                    // treat that as an unresolved citation, split(' ').join('')
+                    // glues every word in the answer together — including headings
+                    // and code. Whitespace is content, never a citation marker.
+                    if (typeof marker !== 'string' || !marker.trim() || !result.includes(marker)) return;
 
                     const item = (Array.isArray(reference.items) ? reference.items : [])
                         .find(candidate => candidate?.url && !isUnsafeHref(String(candidate.url)));

--- a/chatgpt-pdf-exporter.user.js
+++ b/chatgpt-pdf-exporter.user.js
@@ -1475,7 +1475,13 @@
             if (Array.isArray(references)) {
                 references.forEach(reference => {
                     const marker = reference?.matched_text;
-                    if (!marker || !result.includes(marker)) return;
+                    // content_references is not limited to web citations. Current
+                    // ChatGPT payloads can include bookkeeping entries whose
+                    // matched_text is a single space and which carry no URL. If we
+                    // treat that as an unresolved citation, split(' ').join('')
+                    // glues every word in the answer together — including headings
+                    // and code. Whitespace is content, never a citation marker.
+                    if (typeof marker !== 'string' || !marker.trim() || !result.includes(marker)) return;
 
                     const item = (Array.isArray(reference.items) ? reference.items : [])
                         .find(candidate => candidate?.url && !isUnsafeHref(String(candidate.url)));

--- a/exporter-html.js
+++ b/exporter-html.js
@@ -1464,7 +1464,13 @@
             if (Array.isArray(references)) {
                 references.forEach(reference => {
                     const marker = reference?.matched_text;
-                    if (!marker || !result.includes(marker)) return;
+                    // content_references is not limited to web citations. Current
+                    // ChatGPT payloads can include bookkeeping entries whose
+                    // matched_text is a single space and which carry no URL. If we
+                    // treat that as an unresolved citation, split(' ').join('')
+                    // glues every word in the answer together — including headings
+                    // and code. Whitespace is content, never a citation marker.
+                    if (typeof marker !== 'string' || !marker.trim() || !result.includes(marker)) return;
 
                     const item = (Array.isArray(reference.items) ? reference.items : [])
                         .find(candidate => candidate?.url && !isUnsafeHref(String(candidate.url)));

--- a/exporter-markdown.js
+++ b/exporter-markdown.js
@@ -1464,7 +1464,13 @@
             if (Array.isArray(references)) {
                 references.forEach(reference => {
                     const marker = reference?.matched_text;
-                    if (!marker || !result.includes(marker)) return;
+                    // content_references is not limited to web citations. Current
+                    // ChatGPT payloads can include bookkeeping entries whose
+                    // matched_text is a single space and which carry no URL. If we
+                    // treat that as an unresolved citation, split(' ').join('')
+                    // glues every word in the answer together — including headings
+                    // and code. Whitespace is content, never a citation marker.
+                    if (typeof marker !== 'string' || !marker.trim() || !result.includes(marker)) return;
 
                     const item = (Array.isArray(reference.items) ? reference.items : [])
                         .find(candidate => candidate?.url && !isUnsafeHref(String(candidate.url)));

--- a/exporter-pdf.js
+++ b/exporter-pdf.js
@@ -1464,7 +1464,13 @@
             if (Array.isArray(references)) {
                 references.forEach(reference => {
                     const marker = reference?.matched_text;
-                    if (!marker || !result.includes(marker)) return;
+                    // content_references is not limited to web citations. Current
+                    // ChatGPT payloads can include bookkeeping entries whose
+                    // matched_text is a single space and which carry no URL. If we
+                    // treat that as an unresolved citation, split(' ').join('')
+                    // glues every word in the answer together — including headings
+                    // and code. Whitespace is content, never a citation marker.
+                    if (typeof marker !== 'string' || !marker.trim() || !result.includes(marker)) return;
 
                     const item = (Array.isArray(reference.items) ? reference.items : [])
                         .find(candidate => candidate?.url && !isUnsafeHref(String(candidate.url)));

--- a/gemini-exporter-markdown.js
+++ b/gemini-exporter-markdown.js
@@ -1464,7 +1464,13 @@
             if (Array.isArray(references)) {
                 references.forEach(reference => {
                     const marker = reference?.matched_text;
-                    if (!marker || !result.includes(marker)) return;
+                    // content_references is not limited to web citations. Current
+                    // ChatGPT payloads can include bookkeeping entries whose
+                    // matched_text is a single space and which carry no URL. If we
+                    // treat that as an unresolved citation, split(' ').join('')
+                    // glues every word in the answer together — including headings
+                    // and code. Whitespace is content, never a citation marker.
+                    if (typeof marker !== 'string' || !marker.trim() || !result.includes(marker)) return;
 
                     const item = (Array.isArray(reference.items) ? reference.items : [])
                         .find(candidate => candidate?.url && !isUnsafeHref(String(candidate.url)));

--- a/selector-doctor.js
+++ b/selector-doctor.js
@@ -1464,7 +1464,13 @@
             if (Array.isArray(references)) {
                 references.forEach(reference => {
                     const marker = reference?.matched_text;
-                    if (!marker || !result.includes(marker)) return;
+                    // content_references is not limited to web citations. Current
+                    // ChatGPT payloads can include bookkeeping entries whose
+                    // matched_text is a single space and which carry no URL. If we
+                    // treat that as an unresolved citation, split(' ').join('')
+                    // glues every word in the answer together — including headings
+                    // and code. Whitespace is content, never a citation marker.
+                    if (typeof marker !== 'string' || !marker.trim() || !result.includes(marker)) return;
 
                     const item = (Array.isArray(reference.items) ? reference.items : [])
                         .find(candidate => candidate?.url && !isUnsafeHref(String(candidate.url)));

--- a/src/extraction-engine.js
+++ b/src/extraction-engine.js
@@ -1458,7 +1458,13 @@
         if (Array.isArray(references)) {
             references.forEach(reference => {
                 const marker = reference?.matched_text;
-                if (!marker || !result.includes(marker)) return;
+                // content_references is not limited to web citations. Current
+                // ChatGPT payloads can include bookkeeping entries whose
+                // matched_text is a single space and which carry no URL. If we
+                // treat that as an unresolved citation, split(' ').join('')
+                // glues every word in the answer together — including headings
+                // and code. Whitespace is content, never a citation marker.
+                if (typeof marker !== 'string' || !marker.trim() || !result.includes(marker)) return;
 
                 const item = (Array.isArray(reference.items) ? reference.items : [])
                     .find(candidate => candidate?.url && !isUnsafeHref(String(candidate.url)));

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -1388,6 +1388,37 @@ test('stripping citation markers never eats ordinary punctuation', async () => {
     assert.ok(!/[\uE200-\uE20F]/.test(body), 'the marker itself is gone');
 });
 
+test('non-citation payload references never remove spaces from an answer', async () => {
+    // Current ChatGPT payloads can attach non-web bookkeeping references to a
+    // model response. One observed shape uses a literal space as matched_text
+    // and has no items. Treating every content_reference as a citation used to
+    // evaluate split(' ').join('') over the whole response.
+    const payload = payloadWithMessages(['s1', 's2']);
+    payload.mapping['node-s2'].message.content.parts = [
+        '# File reconciliation and hot evolution\n\n' +
+        'The system must not silently invent and run an unvalidated capability provider midway through a live Run.\n\n' +
+        '```text\nLocal divergence is stored as one ordered patch series\n```'
+    ];
+    payload.mapping['node-s2'].message.metadata.content_references = [{
+        matched_text: ' ',
+        type: 'non_web_reference',
+        items: []
+    }];
+
+    const dom = payloadDom();
+    dom.window.fetch = chatGptBackendStub({ payload }).fetch;
+
+    const conversation = await engine.extractConversationFull({
+        document: dom.window.document, provider: 'chatgpt', format: 'markdown', awaitStreaming: false
+    });
+    const body = conversation.messages[1].content;
+
+    assert.match(body, /^# File reconciliation and hot evolution/m);
+    assert.match(body, /The system must not silently invent and run an unvalidated capability provider midway through a live Run\./);
+    assert.match(body, /Local divergence is stored as one ordered patch series/);
+    assert.doesNotMatch(body, /Thesystemmustnot|Localdivergenceisstored/);
+});
+
 test('an image-only turn survives the payload path', async () => {
     // payloadContentText yields '' for a multimodal part, which used to drop the
     // message entirely.


### PR DESCRIPTION
     ChatGPT payloads can contain bookkeeping content_references whose matched_text is a
     single space and which have no citation URL. The citation resolver treated this as
     an unresolved marker and removed every space from the response. This change ignores
     whitespace-only markers and adds a regression test based on the observed export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exported content being concatenated when citation data contained empty or whitespace-only markers.
  * Preserved spaces in headings, code, and regular text across Markdown, HTML, and PDF exports.
  * Genuine citation markers continue to be resolved as before.

* **Tests**
  * Added regression coverage for whitespace-only citation references in exported Markdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->