### PR TITLE
Use the ChatGPT tab title for exports

### DIFF
--- a/chatgpt-markdown-exporter.user.js
+++ b/chatgpt-markdown-exporter.user.js
@@ -133,8 +133,12 @@
                     '[data-message-content], [data-testid*="content"]',
                     '.whitespace-pre-wrap, [class*="whitespace"]'
                 ],
+                // ChatGPT keeps the conversation name in document.title. Its
+                // message bodies also contain ordinary h1 elements, so preferring
+                // the selector cascade makes the title depend on which virtualized
+                // answer happens to be mounted when export starts.
+                preferDocumentTitle: true,
                 titleSelectors: [
-                    'h1:not([class*="hidden"])',
                     '[class*="conversation-title"]',
                     '[data-testid*="conversation-title"]'
                 ]

--- a/chatgpt-pdf-exporter.user.js
+++ b/chatgpt-pdf-exporter.user.js
@@ -133,8 +133,12 @@
                     '[data-message-content], [data-testid*="content"]',
                     '.whitespace-pre-wrap, [class*="whitespace"]'
                 ],
+                // ChatGPT keeps the conversation name in document.title. Its
+                // message bodies also contain ordinary h1 elements, so preferring
+                // the selector cascade makes the title depend on which virtualized
+                // answer happens to be mounted when export starts.
+                preferDocumentTitle: true,
                 titleSelectors: [
-                    'h1:not([class*="hidden"])',
                     '[class*="conversation-title"]',
                     '[data-testid*="conversation-title"]'
                 ]

--- a/exporter-html.js
+++ b/exporter-html.js
@@ -122,8 +122,12 @@
                     '[data-message-content], [data-testid*="content"]',
                     '.whitespace-pre-wrap, [class*="whitespace"]'
                 ],
+                // ChatGPT keeps the conversation name in document.title. Its
+                // message bodies also contain ordinary h1 elements, so preferring
+                // the selector cascade makes the title depend on which virtualized
+                // answer happens to be mounted when export starts.
+                preferDocumentTitle: true,
                 titleSelectors: [
-                    'h1:not([class*="hidden"])',
                     '[class*="conversation-title"]',
                     '[data-testid*="conversation-title"]'
                 ]

--- a/exporter-markdown.js
+++ b/exporter-markdown.js
@@ -122,8 +122,12 @@
                     '[data-message-content], [data-testid*="content"]',
                     '.whitespace-pre-wrap, [class*="whitespace"]'
                 ],
+                // ChatGPT keeps the conversation name in document.title. Its
+                // message bodies also contain ordinary h1 elements, so preferring
+                // the selector cascade makes the title depend on which virtualized
+                // answer happens to be mounted when export starts.
+                preferDocumentTitle: true,
                 titleSelectors: [
-                    'h1:not([class*="hidden"])',
                     '[class*="conversation-title"]',
                     '[data-testid*="conversation-title"]'
                 ]

--- a/exporter-pdf.js
+++ b/exporter-pdf.js
@@ -122,8 +122,12 @@
                     '[data-message-content], [data-testid*="content"]',
                     '.whitespace-pre-wrap, [class*="whitespace"]'
                 ],
+                // ChatGPT keeps the conversation name in document.title. Its
+                // message bodies also contain ordinary h1 elements, so preferring
+                // the selector cascade makes the title depend on which virtualized
+                // answer happens to be mounted when export starts.
+                preferDocumentTitle: true,
                 titleSelectors: [
-                    'h1:not([class*="hidden"])',
                     '[class*="conversation-title"]',
                     '[data-testid*="conversation-title"]'
                 ]

--- a/gemini-exporter-markdown.js
+++ b/gemini-exporter-markdown.js
@@ -122,8 +122,12 @@
                     '[data-message-content], [data-testid*="content"]',
                     '.whitespace-pre-wrap, [class*="whitespace"]'
                 ],
+                // ChatGPT keeps the conversation name in document.title. Its
+                // message bodies also contain ordinary h1 elements, so preferring
+                // the selector cascade makes the title depend on which virtualized
+                // answer happens to be mounted when export starts.
+                preferDocumentTitle: true,
                 titleSelectors: [
-                    'h1:not([class*="hidden"])',
                     '[class*="conversation-title"]',
                     '[data-testid*="conversation-title"]'
                 ]

--- a/selector-doctor.js
+++ b/selector-doctor.js
@@ -122,8 +122,12 @@
                     '[data-message-content], [data-testid*="content"]',
                     '.whitespace-pre-wrap, [class*="whitespace"]'
                 ],
+                // ChatGPT keeps the conversation name in document.title. Its
+                // message bodies also contain ordinary h1 elements, so preferring
+                // the selector cascade makes the title depend on which virtualized
+                // answer happens to be mounted when export starts.
+                preferDocumentTitle: true,
                 titleSelectors: [
-                    'h1:not([class*="hidden"])',
                     '[class*="conversation-title"]',
                     '[data-testid*="conversation-title"]'
                 ]

--- a/src/extraction-engine.js
+++ b/src/extraction-engine.js
@@ -116,8 +116,12 @@
                 '[data-message-content], [data-testid*="content"]',
                 '.whitespace-pre-wrap, [class*="whitespace"]'
             ],
+            // ChatGPT keeps the conversation name in document.title. Its
+            // message bodies also contain ordinary h1 elements, so preferring
+            // the selector cascade makes the title depend on which virtualized
+            // answer happens to be mounted when export starts.
+            preferDocumentTitle: true,
             titleSelectors: [
-                'h1:not([class*="hidden"])',
                 '[class*="conversation-title"]',
                 '[data-testid*="conversation-title"]'
             ]

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -2255,9 +2255,40 @@ test('a title selector matching page chrome cannot outrank the tab title', async
         'the selector that matched the model picker is gone, not merely outranked');
 });
 
-// ChatGPT still keeps [class*="conversation-title"] in its cascade: it matches
-// nothing on the live site today, and there is no evidence its tab title is the
-// better source. The doctor is what makes that bet visible if it ever goes bad.
+test('ChatGPT answer headings never become the conversation title', () => {
+    // Long virtualized conversations mount only a moving window of turns. The
+    // first h1 here could therefore be any answer heading — the supplied page
+    // produced both "Final architecture" and "Revised design" depending on
+    // scroll position, while the tab consistently held the real name.
+    const dom = new JSDOM(`<!DOCTYPE html><html><head><title>Dynamic Workflow Triggers</title></head><body><main>
+        <div data-message-author-role="assistant"><div class="markdown">
+            <h1>Final architecture</h1><p>The strongest design has three layers.</p>
+        </div></div>
+    </main></body></html>`, { url: 'https://chatgpt.com/c/title-from-tab' });
+
+    const conversation = engine.extractConversation({
+        document: dom.window.document, provider: 'chatgpt', format: 'markdown'
+    });
+
+    assert.equal(conversation.title, 'Dynamic Workflow Triggers');
+    assert.match(conversation.messages[0].content, /# Final architecture/,
+        'the answer heading remains content; it just is not promoted to the file title');
+
+    const genericTab = new JSDOM(`<!DOCTYPE html><html><head><title>ChatGPT</title></head><body><main>
+        <div data-message-author-role="assistant"><div class="markdown">
+            <h1>Final architecture</h1><p>The strongest design has three layers.</p>
+        </div></div>
+    </main></body></html>`, { url: 'https://chatgpt.com/c/generic-title' });
+    const genericConversation = engine.extractConversation({
+        document: genericTab.window.document, provider: 'chatgpt', format: 'markdown'
+    });
+    assert.equal(genericConversation.title, 'Conversation with ChatGPT',
+        'even a generic tab title must not make an answer heading look like conversation metadata');
+});
+
+// ChatGPT keeps the selector cascade as a diagnostic and as a fallback for a
+// generic tab title. When it disagrees with a usable tab title, the tab wins
+// and the doctor still exposes the disagreement.
 test('the doctor flags a title selector that disagrees with the tab', async () => {
     const dom = new JSDOM(`<!DOCTYPE html><html><head><title>Migration Runbook</title></head><body><main>
         <div class="conversation-title-pill">GPT-5 Thinking</div>


### PR DESCRIPTION
     ChatGPT answer bodies can contain ordinary `<h1>` elements. Treating the first mounted
     heading as conversation metadata produced unstable titles such as “Final
     architecture” or “Revised design.” This change prefers `document.title`, removes
     generic answer headings from the title selector cascade, and tests both named and
     generic tabs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ChatGPT exports now use the conversation’s meaningful tab title when available.
  - Prevented headings within message content from being incorrectly used as conversation titles.
  - Added a consistent fallback title when the tab title is generic or unavailable.
  - Preserved answer headings as part of the exported message content.

- **Tests**
  - Added regression coverage for title selection, fallback behavior, and heading preservation across export formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->