### PR TITLE
Fold reasoning progress into its final answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ No install, no server, no account: everything runs locally in your browser.
    - **Markdown (.md):** [exporter-markdown.js](https://github.com/rashidazarang/chatgpt-chat-exporter/raw/master/exporter-markdown.js)
    - **HTML (.html):** [exporter-html.js](https://github.com/rashidazarang/chatgpt-chat-exporter/raw/master/exporter-html.js)
    - **PDF (print-ready HTML):** [exporter-pdf.js](https://github.com/rashidazarang/chatgpt-chat-exporter/raw/master/exporter-pdf.js)
+   - To omit ChatGPT's per-answer reasoning/progress blocks, change `const INCLUDE_REASONING = true` to `false` before pasting.
 4. The file downloads automatically, named after your conversation title
 
 ### Google Gemini

--- a/chatgpt-markdown-exporter.user.js
+++ b/chatgpt-markdown-exporter.user.js
@@ -1582,8 +1582,23 @@
             return !['thoughts', 'reasoning_recap', 'code', 'execution_output', 'tool_result'].includes(contentType);
         }
 
+        // Reasoning models can store progress updates as ordinary assistant/text
+        // messages in the payload even though the UI renders them inside one
+        // "Worked for…" disclosure. Content type alone cannot distinguish those
+        // updates from the final answer. At the conversation level the distinction
+        // is structural: one user turn may have many assistant records, but only
+        // the last eligible assistant record before the next user turn is the
+        // visible response.
+        function mainPayloadMessages(entries) {
+            const eligible = entries.filter(isMainPayloadMessage);
+            return eligible.filter((entry, index) => {
+                if (entry.message?.author?.role !== 'assistant') return true;
+                return eligible[index + 1]?.message?.author?.role !== 'assistant';
+            });
+        }
+
         function payloadMessageMatches(conversation, entries) {
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             const byId = new Map(mainEntries.map(entry => [String(entry.message.id || entry.nodeId), entry]));
             const used = new Set();
             const matches = new Map();
@@ -1611,7 +1626,13 @@
 
         function payloadReasoningRecaps(entries) {
             const recaps = new Map();
+            const mainEntries = new Set(mainPayloadMessages(entries));
             let pending = [];
+
+            const appendPending = value => {
+                const text = stripPayloadMarkers(value).trim();
+                if (text && !pending.includes(text)) pending.push(text);
+            };
 
             entries.forEach(entry => {
                 const message = entry.message;
@@ -1619,8 +1640,7 @@
                 const contentType = String(message?.content?.content_type || '').toLowerCase();
 
                 if (role === 'assistant' && contentType === 'reasoning_recap') {
-                    const text = payloadContentText(message.content);
-                    if (text) pending.push(text);
+                    appendPending(payloadContentText(message.content));
                     return;
                 }
 
@@ -1629,7 +1649,16 @@
                     return;
                 }
 
-                if (role === 'assistant' && isMainPayloadMessage(entry) && pending.length > 0) {
+                // ChatGPT stores the updates shown in its "Worked for…"
+                // disclosure as ordinary assistant/text records immediately before
+                // the visible answer. They are not separate conversation turns,
+                // but dropping them loses content the reader can inspect in the UI.
+                if (role === 'assistant' && isMainPayloadMessage(entry) && !mainEntries.has(entry)) {
+                    appendPending(payloadContentText(message.content));
+                    return;
+                }
+
+                if (role === 'assistant' && mainEntries.has(entry) && pending.length > 0) {
                     recaps.set(String(message.id || entry.nodeId), pending.join('\n\n'));
                     pending = [];
                 }
@@ -2100,6 +2129,16 @@
             message.content = `${message.content}${message.content ? '\n\n' : ''}${markdown !== null ? markdown : html}`.trim();
         }
 
+        function prependReasoning(message, recap, format) {
+            if (!recap || message.content.includes(recap)) return;
+
+            const body = sanitizeHtml(recap).replace(/\n/g, '<br>\n');
+            const markup = format === 'markdown'
+                ? `<small><strong>Reasoning / progress:</strong><br>\n${body}</small>`
+                : `<small class="reasoning-recap"><strong>Reasoning / progress:</strong><br>${body}</small>`;
+            message.content = `${markup}${message.content ? '\n\n' : ''}${message.content}`.trim();
+        }
+
         // ─── Payload-first rendering ────────────────────────────────────────────
         // The payload is the markdown the model produced; the DOM is a rendering of
         // it. Reading the source directly avoids every artifact that comes from
@@ -2113,7 +2152,7 @@
         async function renderConversationFromPayload(payload, doc, provider, options) {
             const format = 'markdown';
             const entries = activePayloadMessages(payload);
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             if (mainEntries.length === 0) return null;
 
             const recaps = payloadReasoningRecaps(entries);
@@ -2151,9 +2190,7 @@
                 }
 
                 const recap = recaps.get(String(entry.message.id || entry.nodeId));
-                if (recap && !message.content.includes(recap)) {
-                    appendMessageEnrichment(message, `**Reasoning:** ${recap}`, null, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
 
                 const citations = payloadCitations(entry.message);
                 if (citations.length > 0) {
@@ -2230,7 +2267,7 @@
             // has. Comparing *ids the sweep actually encountered* — not counts —
             // keeps deliberate content dedupe (two identical "ok" turns collapse by
             // design) from reading as a missing message.
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             conversation.expectedMessages = mainEntries.length;
             if (options.seenMessageIds instanceof Set) {
                 conversation.unreachedMessages = mainEntries.filter(entry =>
@@ -2324,11 +2361,7 @@
 
                 const nativeId = String(nativeMessage.id || entry.nodeId);
                 const recap = recaps.get(nativeId);
-                if (recap && !message.content.includes(recap)) {
-                    const markdown = `**Reasoning:** ${recap}`;
-                    const html = `<div class="reasoning-recap"><strong>Reasoning:</strong> ${sanitizeHtml(recap).replace(/\n/g, '<br>')}</div>`;
-                    appendMessageEnrichment(message, format === 'markdown' ? markdown : null, html, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
             }
 
             conversation.metadataStatus = 'enriched';
@@ -2876,7 +2909,7 @@
                 tokenObtained: Boolean(probeOptions.chatGptAuth.token),
                 accountScoped: Boolean(probeOptions.chatGptAuth.accountId),
                 payloadMessages: result.reason === 'ok'
-                    ? activePayloadMessages(result.body).filter(isMainPayloadMessage).length
+                    ? mainPayloadMessages(activePayloadMessages(result.body)).length
                     : 0
             };
         }

--- a/chatgpt-pdf-exporter.user.js
+++ b/chatgpt-pdf-exporter.user.js
@@ -1582,8 +1582,23 @@
             return !['thoughts', 'reasoning_recap', 'code', 'execution_output', 'tool_result'].includes(contentType);
         }
 
+        // Reasoning models can store progress updates as ordinary assistant/text
+        // messages in the payload even though the UI renders them inside one
+        // "Worked for…" disclosure. Content type alone cannot distinguish those
+        // updates from the final answer. At the conversation level the distinction
+        // is structural: one user turn may have many assistant records, but only
+        // the last eligible assistant record before the next user turn is the
+        // visible response.
+        function mainPayloadMessages(entries) {
+            const eligible = entries.filter(isMainPayloadMessage);
+            return eligible.filter((entry, index) => {
+                if (entry.message?.author?.role !== 'assistant') return true;
+                return eligible[index + 1]?.message?.author?.role !== 'assistant';
+            });
+        }
+
         function payloadMessageMatches(conversation, entries) {
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             const byId = new Map(mainEntries.map(entry => [String(entry.message.id || entry.nodeId), entry]));
             const used = new Set();
             const matches = new Map();
@@ -1611,7 +1626,13 @@
 
         function payloadReasoningRecaps(entries) {
             const recaps = new Map();
+            const mainEntries = new Set(mainPayloadMessages(entries));
             let pending = [];
+
+            const appendPending = value => {
+                const text = stripPayloadMarkers(value).trim();
+                if (text && !pending.includes(text)) pending.push(text);
+            };
 
             entries.forEach(entry => {
                 const message = entry.message;
@@ -1619,8 +1640,7 @@
                 const contentType = String(message?.content?.content_type || '').toLowerCase();
 
                 if (role === 'assistant' && contentType === 'reasoning_recap') {
-                    const text = payloadContentText(message.content);
-                    if (text) pending.push(text);
+                    appendPending(payloadContentText(message.content));
                     return;
                 }
 
@@ -1629,7 +1649,16 @@
                     return;
                 }
 
-                if (role === 'assistant' && isMainPayloadMessage(entry) && pending.length > 0) {
+                // ChatGPT stores the updates shown in its "Worked for…"
+                // disclosure as ordinary assistant/text records immediately before
+                // the visible answer. They are not separate conversation turns,
+                // but dropping them loses content the reader can inspect in the UI.
+                if (role === 'assistant' && isMainPayloadMessage(entry) && !mainEntries.has(entry)) {
+                    appendPending(payloadContentText(message.content));
+                    return;
+                }
+
+                if (role === 'assistant' && mainEntries.has(entry) && pending.length > 0) {
                     recaps.set(String(message.id || entry.nodeId), pending.join('\n\n'));
                     pending = [];
                 }
@@ -2100,6 +2129,16 @@
             message.content = `${message.content}${message.content ? '\n\n' : ''}${markdown !== null ? markdown : html}`.trim();
         }
 
+        function prependReasoning(message, recap, format) {
+            if (!recap || message.content.includes(recap)) return;
+
+            const body = sanitizeHtml(recap).replace(/\n/g, '<br>\n');
+            const markup = format === 'markdown'
+                ? `<small><strong>Reasoning / progress:</strong><br>\n${body}</small>`
+                : `<small class="reasoning-recap"><strong>Reasoning / progress:</strong><br>${body}</small>`;
+            message.content = `${markup}${message.content ? '\n\n' : ''}${message.content}`.trim();
+        }
+
         // ─── Payload-first rendering ────────────────────────────────────────────
         // The payload is the markdown the model produced; the DOM is a rendering of
         // it. Reading the source directly avoids every artifact that comes from
@@ -2113,7 +2152,7 @@
         async function renderConversationFromPayload(payload, doc, provider, options) {
             const format = 'markdown';
             const entries = activePayloadMessages(payload);
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             if (mainEntries.length === 0) return null;
 
             const recaps = payloadReasoningRecaps(entries);
@@ -2151,9 +2190,7 @@
                 }
 
                 const recap = recaps.get(String(entry.message.id || entry.nodeId));
-                if (recap && !message.content.includes(recap)) {
-                    appendMessageEnrichment(message, `**Reasoning:** ${recap}`, null, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
 
                 const citations = payloadCitations(entry.message);
                 if (citations.length > 0) {
@@ -2230,7 +2267,7 @@
             // has. Comparing *ids the sweep actually encountered* — not counts —
             // keeps deliberate content dedupe (two identical "ok" turns collapse by
             // design) from reading as a missing message.
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             conversation.expectedMessages = mainEntries.length;
             if (options.seenMessageIds instanceof Set) {
                 conversation.unreachedMessages = mainEntries.filter(entry =>
@@ -2324,11 +2361,7 @@
 
                 const nativeId = String(nativeMessage.id || entry.nodeId);
                 const recap = recaps.get(nativeId);
-                if (recap && !message.content.includes(recap)) {
-                    const markdown = `**Reasoning:** ${recap}`;
-                    const html = `<div class="reasoning-recap"><strong>Reasoning:</strong> ${sanitizeHtml(recap).replace(/\n/g, '<br>')}</div>`;
-                    appendMessageEnrichment(message, format === 'markdown' ? markdown : null, html, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
             }
 
             conversation.metadataStatus = 'enriched';
@@ -2876,7 +2909,7 @@
                 tokenObtained: Boolean(probeOptions.chatGptAuth.token),
                 accountScoped: Boolean(probeOptions.chatGptAuth.accountId),
                 payloadMessages: result.reason === 'ok'
-                    ? activePayloadMessages(result.body).filter(isMainPayloadMessage).length
+                    ? mainPayloadMessages(activePayloadMessages(result.body)).length
                     : 0
             };
         }

--- a/exporter-html.js
+++ b/exporter-html.js
@@ -4,6 +4,9 @@
 (() => {
     'use strict';
 
+    // Set to false to omit ChatGPT's per-answer reasoning/progress updates.
+    const INCLUDE_REASONING = true;
+
     (function initChatExporterEngine(root, factory) {
         const engine = factory();
 
@@ -1571,8 +1574,23 @@
             return !['thoughts', 'reasoning_recap', 'code', 'execution_output', 'tool_result'].includes(contentType);
         }
 
+        // Reasoning models can store progress updates as ordinary assistant/text
+        // messages in the payload even though the UI renders them inside one
+        // "Worked for…" disclosure. Content type alone cannot distinguish those
+        // updates from the final answer. At the conversation level the distinction
+        // is structural: one user turn may have many assistant records, but only
+        // the last eligible assistant record before the next user turn is the
+        // visible response.
+        function mainPayloadMessages(entries) {
+            const eligible = entries.filter(isMainPayloadMessage);
+            return eligible.filter((entry, index) => {
+                if (entry.message?.author?.role !== 'assistant') return true;
+                return eligible[index + 1]?.message?.author?.role !== 'assistant';
+            });
+        }
+
         function payloadMessageMatches(conversation, entries) {
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             const byId = new Map(mainEntries.map(entry => [String(entry.message.id || entry.nodeId), entry]));
             const used = new Set();
             const matches = new Map();
@@ -1600,7 +1618,13 @@
 
         function payloadReasoningRecaps(entries) {
             const recaps = new Map();
+            const mainEntries = new Set(mainPayloadMessages(entries));
             let pending = [];
+
+            const appendPending = value => {
+                const text = stripPayloadMarkers(value).trim();
+                if (text && !pending.includes(text)) pending.push(text);
+            };
 
             entries.forEach(entry => {
                 const message = entry.message;
@@ -1608,8 +1632,7 @@
                 const contentType = String(message?.content?.content_type || '').toLowerCase();
 
                 if (role === 'assistant' && contentType === 'reasoning_recap') {
-                    const text = payloadContentText(message.content);
-                    if (text) pending.push(text);
+                    appendPending(payloadContentText(message.content));
                     return;
                 }
 
@@ -1618,7 +1641,16 @@
                     return;
                 }
 
-                if (role === 'assistant' && isMainPayloadMessage(entry) && pending.length > 0) {
+                // ChatGPT stores the updates shown in its "Worked for…"
+                // disclosure as ordinary assistant/text records immediately before
+                // the visible answer. They are not separate conversation turns,
+                // but dropping them loses content the reader can inspect in the UI.
+                if (role === 'assistant' && isMainPayloadMessage(entry) && !mainEntries.has(entry)) {
+                    appendPending(payloadContentText(message.content));
+                    return;
+                }
+
+                if (role === 'assistant' && mainEntries.has(entry) && pending.length > 0) {
                     recaps.set(String(message.id || entry.nodeId), pending.join('\n\n'));
                     pending = [];
                 }
@@ -2089,6 +2121,16 @@
             message.content = `${message.content}${message.content ? '\n\n' : ''}${markdown !== null ? markdown : html}`.trim();
         }
 
+        function prependReasoning(message, recap, format) {
+            if (!recap || message.content.includes(recap)) return;
+
+            const body = sanitizeHtml(recap).replace(/\n/g, '<br>\n');
+            const markup = format === 'markdown'
+                ? `<small><strong>Reasoning / progress:</strong><br>\n${body}</small>`
+                : `<small class="reasoning-recap"><strong>Reasoning / progress:</strong><br>${body}</small>`;
+            message.content = `${markup}${message.content ? '\n\n' : ''}${message.content}`.trim();
+        }
+
         // ─── Payload-first rendering ────────────────────────────────────────────
         // The payload is the markdown the model produced; the DOM is a rendering of
         // it. Reading the source directly avoids every artifact that comes from
@@ -2102,7 +2144,7 @@
         async function renderConversationFromPayload(payload, doc, provider, options) {
             const format = 'markdown';
             const entries = activePayloadMessages(payload);
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             if (mainEntries.length === 0) return null;
 
             const recaps = payloadReasoningRecaps(entries);
@@ -2140,9 +2182,7 @@
                 }
 
                 const recap = recaps.get(String(entry.message.id || entry.nodeId));
-                if (recap && !message.content.includes(recap)) {
-                    appendMessageEnrichment(message, `**Reasoning:** ${recap}`, null, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
 
                 const citations = payloadCitations(entry.message);
                 if (citations.length > 0) {
@@ -2219,7 +2259,7 @@
             // has. Comparing *ids the sweep actually encountered* — not counts —
             // keeps deliberate content dedupe (two identical "ok" turns collapse by
             // design) from reading as a missing message.
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             conversation.expectedMessages = mainEntries.length;
             if (options.seenMessageIds instanceof Set) {
                 conversation.unreachedMessages = mainEntries.filter(entry =>
@@ -2313,11 +2353,7 @@
 
                 const nativeId = String(nativeMessage.id || entry.nodeId);
                 const recap = recaps.get(nativeId);
-                if (recap && !message.content.includes(recap)) {
-                    const markdown = `**Reasoning:** ${recap}`;
-                    const html = `<div class="reasoning-recap"><strong>Reasoning:</strong> ${sanitizeHtml(recap).replace(/\n/g, '<br>')}</div>`;
-                    appendMessageEnrichment(message, format === 'markdown' ? markdown : null, html, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
             }
 
             conversation.metadataStatus = 'enriched';
@@ -2865,7 +2901,7 @@
                 tokenObtained: Boolean(probeOptions.chatGptAuth.token),
                 accountScoped: Boolean(probeOptions.chatGptAuth.accountId),
                 payloadMessages: result.reason === 'ok'
-                    ? activePayloadMessages(result.body).filter(isMainPayloadMessage).length
+                    ? mainPayloadMessages(activePayloadMessages(result.body)).length
                     : 0
             };
         }
@@ -3539,6 +3575,7 @@
     globalThis.ChatExporterEngine.exportConversationFull({
         provider: 'chatgpt',
         format: 'html',
+        includeReasoning: INCLUDE_REASONING,
         onProgress: progress.onProgress
     }).catch(error => {
         progress.destroy();

--- a/exporter-markdown.js
+++ b/exporter-markdown.js
@@ -4,6 +4,9 @@
 (() => {
     'use strict';
 
+    // Set to false to omit ChatGPT's per-answer reasoning/progress updates.
+    const INCLUDE_REASONING = true;
+
     (function initChatExporterEngine(root, factory) {
         const engine = factory();
 
@@ -1571,8 +1574,23 @@
             return !['thoughts', 'reasoning_recap', 'code', 'execution_output', 'tool_result'].includes(contentType);
         }
 
+        // Reasoning models can store progress updates as ordinary assistant/text
+        // messages in the payload even though the UI renders them inside one
+        // "Worked for…" disclosure. Content type alone cannot distinguish those
+        // updates from the final answer. At the conversation level the distinction
+        // is structural: one user turn may have many assistant records, but only
+        // the last eligible assistant record before the next user turn is the
+        // visible response.
+        function mainPayloadMessages(entries) {
+            const eligible = entries.filter(isMainPayloadMessage);
+            return eligible.filter((entry, index) => {
+                if (entry.message?.author?.role !== 'assistant') return true;
+                return eligible[index + 1]?.message?.author?.role !== 'assistant';
+            });
+        }
+
         function payloadMessageMatches(conversation, entries) {
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             const byId = new Map(mainEntries.map(entry => [String(entry.message.id || entry.nodeId), entry]));
             const used = new Set();
             const matches = new Map();
@@ -1600,7 +1618,13 @@
 
         function payloadReasoningRecaps(entries) {
             const recaps = new Map();
+            const mainEntries = new Set(mainPayloadMessages(entries));
             let pending = [];
+
+            const appendPending = value => {
+                const text = stripPayloadMarkers(value).trim();
+                if (text && !pending.includes(text)) pending.push(text);
+            };
 
             entries.forEach(entry => {
                 const message = entry.message;
@@ -1608,8 +1632,7 @@
                 const contentType = String(message?.content?.content_type || '').toLowerCase();
 
                 if (role === 'assistant' && contentType === 'reasoning_recap') {
-                    const text = payloadContentText(message.content);
-                    if (text) pending.push(text);
+                    appendPending(payloadContentText(message.content));
                     return;
                 }
 
@@ -1618,7 +1641,16 @@
                     return;
                 }
 
-                if (role === 'assistant' && isMainPayloadMessage(entry) && pending.length > 0) {
+                // ChatGPT stores the updates shown in its "Worked for…"
+                // disclosure as ordinary assistant/text records immediately before
+                // the visible answer. They are not separate conversation turns,
+                // but dropping them loses content the reader can inspect in the UI.
+                if (role === 'assistant' && isMainPayloadMessage(entry) && !mainEntries.has(entry)) {
+                    appendPending(payloadContentText(message.content));
+                    return;
+                }
+
+                if (role === 'assistant' && mainEntries.has(entry) && pending.length > 0) {
                     recaps.set(String(message.id || entry.nodeId), pending.join('\n\n'));
                     pending = [];
                 }
@@ -2089,6 +2121,16 @@
             message.content = `${message.content}${message.content ? '\n\n' : ''}${markdown !== null ? markdown : html}`.trim();
         }
 
+        function prependReasoning(message, recap, format) {
+            if (!recap || message.content.includes(recap)) return;
+
+            const body = sanitizeHtml(recap).replace(/\n/g, '<br>\n');
+            const markup = format === 'markdown'
+                ? `<small><strong>Reasoning / progress:</strong><br>\n${body}</small>`
+                : `<small class="reasoning-recap"><strong>Reasoning / progress:</strong><br>${body}</small>`;
+            message.content = `${markup}${message.content ? '\n\n' : ''}${message.content}`.trim();
+        }
+
         // ─── Payload-first rendering ────────────────────────────────────────────
         // The payload is the markdown the model produced; the DOM is a rendering of
         // it. Reading the source directly avoids every artifact that comes from
@@ -2102,7 +2144,7 @@
         async function renderConversationFromPayload(payload, doc, provider, options) {
             const format = 'markdown';
             const entries = activePayloadMessages(payload);
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             if (mainEntries.length === 0) return null;
 
             const recaps = payloadReasoningRecaps(entries);
@@ -2140,9 +2182,7 @@
                 }
 
                 const recap = recaps.get(String(entry.message.id || entry.nodeId));
-                if (recap && !message.content.includes(recap)) {
-                    appendMessageEnrichment(message, `**Reasoning:** ${recap}`, null, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
 
                 const citations = payloadCitations(entry.message);
                 if (citations.length > 0) {
@@ -2219,7 +2259,7 @@
             // has. Comparing *ids the sweep actually encountered* — not counts —
             // keeps deliberate content dedupe (two identical "ok" turns collapse by
             // design) from reading as a missing message.
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             conversation.expectedMessages = mainEntries.length;
             if (options.seenMessageIds instanceof Set) {
                 conversation.unreachedMessages = mainEntries.filter(entry =>
@@ -2313,11 +2353,7 @@
 
                 const nativeId = String(nativeMessage.id || entry.nodeId);
                 const recap = recaps.get(nativeId);
-                if (recap && !message.content.includes(recap)) {
-                    const markdown = `**Reasoning:** ${recap}`;
-                    const html = `<div class="reasoning-recap"><strong>Reasoning:</strong> ${sanitizeHtml(recap).replace(/\n/g, '<br>')}</div>`;
-                    appendMessageEnrichment(message, format === 'markdown' ? markdown : null, html, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
             }
 
             conversation.metadataStatus = 'enriched';
@@ -2865,7 +2901,7 @@
                 tokenObtained: Boolean(probeOptions.chatGptAuth.token),
                 accountScoped: Boolean(probeOptions.chatGptAuth.accountId),
                 payloadMessages: result.reason === 'ok'
-                    ? activePayloadMessages(result.body).filter(isMainPayloadMessage).length
+                    ? mainPayloadMessages(activePayloadMessages(result.body)).length
                     : 0
             };
         }
@@ -3539,6 +3575,7 @@
     globalThis.ChatExporterEngine.exportConversationFull({
         provider: 'chatgpt',
         format: 'markdown',
+        includeReasoning: INCLUDE_REASONING,
         onProgress: progress.onProgress
     }).catch(error => {
         progress.destroy();

--- a/exporter-pdf.js
+++ b/exporter-pdf.js
@@ -4,6 +4,9 @@
 (() => {
     'use strict';
 
+    // Set to false to omit ChatGPT's per-answer reasoning/progress updates.
+    const INCLUDE_REASONING = true;
+
     (function initChatExporterEngine(root, factory) {
         const engine = factory();
 
@@ -1571,8 +1574,23 @@
             return !['thoughts', 'reasoning_recap', 'code', 'execution_output', 'tool_result'].includes(contentType);
         }
 
+        // Reasoning models can store progress updates as ordinary assistant/text
+        // messages in the payload even though the UI renders them inside one
+        // "Worked for…" disclosure. Content type alone cannot distinguish those
+        // updates from the final answer. At the conversation level the distinction
+        // is structural: one user turn may have many assistant records, but only
+        // the last eligible assistant record before the next user turn is the
+        // visible response.
+        function mainPayloadMessages(entries) {
+            const eligible = entries.filter(isMainPayloadMessage);
+            return eligible.filter((entry, index) => {
+                if (entry.message?.author?.role !== 'assistant') return true;
+                return eligible[index + 1]?.message?.author?.role !== 'assistant';
+            });
+        }
+
         function payloadMessageMatches(conversation, entries) {
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             const byId = new Map(mainEntries.map(entry => [String(entry.message.id || entry.nodeId), entry]));
             const used = new Set();
             const matches = new Map();
@@ -1600,7 +1618,13 @@
 
         function payloadReasoningRecaps(entries) {
             const recaps = new Map();
+            const mainEntries = new Set(mainPayloadMessages(entries));
             let pending = [];
+
+            const appendPending = value => {
+                const text = stripPayloadMarkers(value).trim();
+                if (text && !pending.includes(text)) pending.push(text);
+            };
 
             entries.forEach(entry => {
                 const message = entry.message;
@@ -1608,8 +1632,7 @@
                 const contentType = String(message?.content?.content_type || '').toLowerCase();
 
                 if (role === 'assistant' && contentType === 'reasoning_recap') {
-                    const text = payloadContentText(message.content);
-                    if (text) pending.push(text);
+                    appendPending(payloadContentText(message.content));
                     return;
                 }
 
@@ -1618,7 +1641,16 @@
                     return;
                 }
 
-                if (role === 'assistant' && isMainPayloadMessage(entry) && pending.length > 0) {
+                // ChatGPT stores the updates shown in its "Worked for…"
+                // disclosure as ordinary assistant/text records immediately before
+                // the visible answer. They are not separate conversation turns,
+                // but dropping them loses content the reader can inspect in the UI.
+                if (role === 'assistant' && isMainPayloadMessage(entry) && !mainEntries.has(entry)) {
+                    appendPending(payloadContentText(message.content));
+                    return;
+                }
+
+                if (role === 'assistant' && mainEntries.has(entry) && pending.length > 0) {
                     recaps.set(String(message.id || entry.nodeId), pending.join('\n\n'));
                     pending = [];
                 }
@@ -2089,6 +2121,16 @@
             message.content = `${message.content}${message.content ? '\n\n' : ''}${markdown !== null ? markdown : html}`.trim();
         }
 
+        function prependReasoning(message, recap, format) {
+            if (!recap || message.content.includes(recap)) return;
+
+            const body = sanitizeHtml(recap).replace(/\n/g, '<br>\n');
+            const markup = format === 'markdown'
+                ? `<small><strong>Reasoning / progress:</strong><br>\n${body}</small>`
+                : `<small class="reasoning-recap"><strong>Reasoning / progress:</strong><br>${body}</small>`;
+            message.content = `${markup}${message.content ? '\n\n' : ''}${message.content}`.trim();
+        }
+
         // ─── Payload-first rendering ────────────────────────────────────────────
         // The payload is the markdown the model produced; the DOM is a rendering of
         // it. Reading the source directly avoids every artifact that comes from
@@ -2102,7 +2144,7 @@
         async function renderConversationFromPayload(payload, doc, provider, options) {
             const format = 'markdown';
             const entries = activePayloadMessages(payload);
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             if (mainEntries.length === 0) return null;
 
             const recaps = payloadReasoningRecaps(entries);
@@ -2140,9 +2182,7 @@
                 }
 
                 const recap = recaps.get(String(entry.message.id || entry.nodeId));
-                if (recap && !message.content.includes(recap)) {
-                    appendMessageEnrichment(message, `**Reasoning:** ${recap}`, null, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
 
                 const citations = payloadCitations(entry.message);
                 if (citations.length > 0) {
@@ -2219,7 +2259,7 @@
             // has. Comparing *ids the sweep actually encountered* — not counts —
             // keeps deliberate content dedupe (two identical "ok" turns collapse by
             // design) from reading as a missing message.
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             conversation.expectedMessages = mainEntries.length;
             if (options.seenMessageIds instanceof Set) {
                 conversation.unreachedMessages = mainEntries.filter(entry =>
@@ -2313,11 +2353,7 @@
 
                 const nativeId = String(nativeMessage.id || entry.nodeId);
                 const recap = recaps.get(nativeId);
-                if (recap && !message.content.includes(recap)) {
-                    const markdown = `**Reasoning:** ${recap}`;
-                    const html = `<div class="reasoning-recap"><strong>Reasoning:</strong> ${sanitizeHtml(recap).replace(/\n/g, '<br>')}</div>`;
-                    appendMessageEnrichment(message, format === 'markdown' ? markdown : null, html, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
             }
 
             conversation.metadataStatus = 'enriched';
@@ -2865,7 +2901,7 @@
                 tokenObtained: Boolean(probeOptions.chatGptAuth.token),
                 accountScoped: Boolean(probeOptions.chatGptAuth.accountId),
                 payloadMessages: result.reason === 'ok'
-                    ? activePayloadMessages(result.body).filter(isMainPayloadMessage).length
+                    ? mainPayloadMessages(activePayloadMessages(result.body)).length
                     : 0
             };
         }
@@ -3539,6 +3575,7 @@
     globalThis.ChatExporterEngine.exportConversationFull({
         provider: 'chatgpt',
         format: 'pdf',
+        includeReasoning: INCLUDE_REASONING,
         onProgress: progress.onProgress
     }).catch(error => {
         progress.destroy();

--- a/gemini-exporter-markdown.js
+++ b/gemini-exporter-markdown.js
@@ -4,6 +4,9 @@
 (() => {
     'use strict';
 
+    // Set to false to omit ChatGPT's per-answer reasoning/progress updates.
+    const INCLUDE_REASONING = true;
+
     (function initChatExporterEngine(root, factory) {
         const engine = factory();
 
@@ -1571,8 +1574,23 @@
             return !['thoughts', 'reasoning_recap', 'code', 'execution_output', 'tool_result'].includes(contentType);
         }
 
+        // Reasoning models can store progress updates as ordinary assistant/text
+        // messages in the payload even though the UI renders them inside one
+        // "Worked for…" disclosure. Content type alone cannot distinguish those
+        // updates from the final answer. At the conversation level the distinction
+        // is structural: one user turn may have many assistant records, but only
+        // the last eligible assistant record before the next user turn is the
+        // visible response.
+        function mainPayloadMessages(entries) {
+            const eligible = entries.filter(isMainPayloadMessage);
+            return eligible.filter((entry, index) => {
+                if (entry.message?.author?.role !== 'assistant') return true;
+                return eligible[index + 1]?.message?.author?.role !== 'assistant';
+            });
+        }
+
         function payloadMessageMatches(conversation, entries) {
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             const byId = new Map(mainEntries.map(entry => [String(entry.message.id || entry.nodeId), entry]));
             const used = new Set();
             const matches = new Map();
@@ -1600,7 +1618,13 @@
 
         function payloadReasoningRecaps(entries) {
             const recaps = new Map();
+            const mainEntries = new Set(mainPayloadMessages(entries));
             let pending = [];
+
+            const appendPending = value => {
+                const text = stripPayloadMarkers(value).trim();
+                if (text && !pending.includes(text)) pending.push(text);
+            };
 
             entries.forEach(entry => {
                 const message = entry.message;
@@ -1608,8 +1632,7 @@
                 const contentType = String(message?.content?.content_type || '').toLowerCase();
 
                 if (role === 'assistant' && contentType === 'reasoning_recap') {
-                    const text = payloadContentText(message.content);
-                    if (text) pending.push(text);
+                    appendPending(payloadContentText(message.content));
                     return;
                 }
 
@@ -1618,7 +1641,16 @@
                     return;
                 }
 
-                if (role === 'assistant' && isMainPayloadMessage(entry) && pending.length > 0) {
+                // ChatGPT stores the updates shown in its "Worked for…"
+                // disclosure as ordinary assistant/text records immediately before
+                // the visible answer. They are not separate conversation turns,
+                // but dropping them loses content the reader can inspect in the UI.
+                if (role === 'assistant' && isMainPayloadMessage(entry) && !mainEntries.has(entry)) {
+                    appendPending(payloadContentText(message.content));
+                    return;
+                }
+
+                if (role === 'assistant' && mainEntries.has(entry) && pending.length > 0) {
                     recaps.set(String(message.id || entry.nodeId), pending.join('\n\n'));
                     pending = [];
                 }
@@ -2089,6 +2121,16 @@
             message.content = `${message.content}${message.content ? '\n\n' : ''}${markdown !== null ? markdown : html}`.trim();
         }
 
+        function prependReasoning(message, recap, format) {
+            if (!recap || message.content.includes(recap)) return;
+
+            const body = sanitizeHtml(recap).replace(/\n/g, '<br>\n');
+            const markup = format === 'markdown'
+                ? `<small><strong>Reasoning / progress:</strong><br>\n${body}</small>`
+                : `<small class="reasoning-recap"><strong>Reasoning / progress:</strong><br>${body}</small>`;
+            message.content = `${markup}${message.content ? '\n\n' : ''}${message.content}`.trim();
+        }
+
         // ─── Payload-first rendering ────────────────────────────────────────────
         // The payload is the markdown the model produced; the DOM is a rendering of
         // it. Reading the source directly avoids every artifact that comes from
@@ -2102,7 +2144,7 @@
         async function renderConversationFromPayload(payload, doc, provider, options) {
             const format = 'markdown';
             const entries = activePayloadMessages(payload);
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             if (mainEntries.length === 0) return null;
 
             const recaps = payloadReasoningRecaps(entries);
@@ -2140,9 +2182,7 @@
                 }
 
                 const recap = recaps.get(String(entry.message.id || entry.nodeId));
-                if (recap && !message.content.includes(recap)) {
-                    appendMessageEnrichment(message, `**Reasoning:** ${recap}`, null, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
 
                 const citations = payloadCitations(entry.message);
                 if (citations.length > 0) {
@@ -2219,7 +2259,7 @@
             // has. Comparing *ids the sweep actually encountered* — not counts —
             // keeps deliberate content dedupe (two identical "ok" turns collapse by
             // design) from reading as a missing message.
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             conversation.expectedMessages = mainEntries.length;
             if (options.seenMessageIds instanceof Set) {
                 conversation.unreachedMessages = mainEntries.filter(entry =>
@@ -2313,11 +2353,7 @@
 
                 const nativeId = String(nativeMessage.id || entry.nodeId);
                 const recap = recaps.get(nativeId);
-                if (recap && !message.content.includes(recap)) {
-                    const markdown = `**Reasoning:** ${recap}`;
-                    const html = `<div class="reasoning-recap"><strong>Reasoning:</strong> ${sanitizeHtml(recap).replace(/\n/g, '<br>')}</div>`;
-                    appendMessageEnrichment(message, format === 'markdown' ? markdown : null, html, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
             }
 
             conversation.metadataStatus = 'enriched';
@@ -2865,7 +2901,7 @@
                 tokenObtained: Boolean(probeOptions.chatGptAuth.token),
                 accountScoped: Boolean(probeOptions.chatGptAuth.accountId),
                 payloadMessages: result.reason === 'ok'
-                    ? activePayloadMessages(result.body).filter(isMainPayloadMessage).length
+                    ? mainPayloadMessages(activePayloadMessages(result.body)).length
                     : 0
             };
         }
@@ -3539,6 +3575,7 @@
     globalThis.ChatExporterEngine.exportConversationFull({
         provider: 'gemini',
         format: 'markdown',
+        includeReasoning: INCLUDE_REASONING,
         onProgress: progress.onProgress
     }).catch(error => {
         progress.destroy();

--- a/scripts/build-exporters.js
+++ b/scripts/build-exporters.js
@@ -17,6 +17,9 @@ function runner(provider, format) {
     return `${GENERATED_NOTICE}(() => {
     'use strict';
 
+    // Set to false to omit ChatGPT's per-answer reasoning/progress updates.
+    const INCLUDE_REASONING = true;
+
 ${indent(engineSource, 4)}
 
 ${indent(progressOverlaySource, 4)}
@@ -28,6 +31,7 @@ ${indent(progressOverlaySource, 4)}
     globalThis.ChatExporterEngine.exportConversationFull({
         provider: '${provider}',
         format: '${format}',
+        includeReasoning: INCLUDE_REASONING,
         onProgress: progress.onProgress
     }).catch(error => {
         progress.destroy();

--- a/selector-doctor.js
+++ b/selector-doctor.js
@@ -1571,8 +1571,23 @@
             return !['thoughts', 'reasoning_recap', 'code', 'execution_output', 'tool_result'].includes(contentType);
         }
 
+        // Reasoning models can store progress updates as ordinary assistant/text
+        // messages in the payload even though the UI renders them inside one
+        // "Worked for…" disclosure. Content type alone cannot distinguish those
+        // updates from the final answer. At the conversation level the distinction
+        // is structural: one user turn may have many assistant records, but only
+        // the last eligible assistant record before the next user turn is the
+        // visible response.
+        function mainPayloadMessages(entries) {
+            const eligible = entries.filter(isMainPayloadMessage);
+            return eligible.filter((entry, index) => {
+                if (entry.message?.author?.role !== 'assistant') return true;
+                return eligible[index + 1]?.message?.author?.role !== 'assistant';
+            });
+        }
+
         function payloadMessageMatches(conversation, entries) {
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             const byId = new Map(mainEntries.map(entry => [String(entry.message.id || entry.nodeId), entry]));
             const used = new Set();
             const matches = new Map();
@@ -1600,7 +1615,13 @@
 
         function payloadReasoningRecaps(entries) {
             const recaps = new Map();
+            const mainEntries = new Set(mainPayloadMessages(entries));
             let pending = [];
+
+            const appendPending = value => {
+                const text = stripPayloadMarkers(value).trim();
+                if (text && !pending.includes(text)) pending.push(text);
+            };
 
             entries.forEach(entry => {
                 const message = entry.message;
@@ -1608,8 +1629,7 @@
                 const contentType = String(message?.content?.content_type || '').toLowerCase();
 
                 if (role === 'assistant' && contentType === 'reasoning_recap') {
-                    const text = payloadContentText(message.content);
-                    if (text) pending.push(text);
+                    appendPending(payloadContentText(message.content));
                     return;
                 }
 
@@ -1618,7 +1638,16 @@
                     return;
                 }
 
-                if (role === 'assistant' && isMainPayloadMessage(entry) && pending.length > 0) {
+                // ChatGPT stores the updates shown in its "Worked for…"
+                // disclosure as ordinary assistant/text records immediately before
+                // the visible answer. They are not separate conversation turns,
+                // but dropping them loses content the reader can inspect in the UI.
+                if (role === 'assistant' && isMainPayloadMessage(entry) && !mainEntries.has(entry)) {
+                    appendPending(payloadContentText(message.content));
+                    return;
+                }
+
+                if (role === 'assistant' && mainEntries.has(entry) && pending.length > 0) {
                     recaps.set(String(message.id || entry.nodeId), pending.join('\n\n'));
                     pending = [];
                 }
@@ -2089,6 +2118,16 @@
             message.content = `${message.content}${message.content ? '\n\n' : ''}${markdown !== null ? markdown : html}`.trim();
         }
 
+        function prependReasoning(message, recap, format) {
+            if (!recap || message.content.includes(recap)) return;
+
+            const body = sanitizeHtml(recap).replace(/\n/g, '<br>\n');
+            const markup = format === 'markdown'
+                ? `<small><strong>Reasoning / progress:</strong><br>\n${body}</small>`
+                : `<small class="reasoning-recap"><strong>Reasoning / progress:</strong><br>${body}</small>`;
+            message.content = `${markup}${message.content ? '\n\n' : ''}${message.content}`.trim();
+        }
+
         // ─── Payload-first rendering ────────────────────────────────────────────
         // The payload is the markdown the model produced; the DOM is a rendering of
         // it. Reading the source directly avoids every artifact that comes from
@@ -2102,7 +2141,7 @@
         async function renderConversationFromPayload(payload, doc, provider, options) {
             const format = 'markdown';
             const entries = activePayloadMessages(payload);
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             if (mainEntries.length === 0) return null;
 
             const recaps = payloadReasoningRecaps(entries);
@@ -2140,9 +2179,7 @@
                 }
 
                 const recap = recaps.get(String(entry.message.id || entry.nodeId));
-                if (recap && !message.content.includes(recap)) {
-                    appendMessageEnrichment(message, `**Reasoning:** ${recap}`, null, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
 
                 const citations = payloadCitations(entry.message);
                 if (citations.length > 0) {
@@ -2219,7 +2256,7 @@
             // has. Comparing *ids the sweep actually encountered* — not counts —
             // keeps deliberate content dedupe (two identical "ok" turns collapse by
             // design) from reading as a missing message.
-            const mainEntries = entries.filter(isMainPayloadMessage);
+            const mainEntries = mainPayloadMessages(entries);
             conversation.expectedMessages = mainEntries.length;
             if (options.seenMessageIds instanceof Set) {
                 conversation.unreachedMessages = mainEntries.filter(entry =>
@@ -2313,11 +2350,7 @@
 
                 const nativeId = String(nativeMessage.id || entry.nodeId);
                 const recap = recaps.get(nativeId);
-                if (recap && !message.content.includes(recap)) {
-                    const markdown = `**Reasoning:** ${recap}`;
-                    const html = `<div class="reasoning-recap"><strong>Reasoning:</strong> ${sanitizeHtml(recap).replace(/\n/g, '<br>')}</div>`;
-                    appendMessageEnrichment(message, format === 'markdown' ? markdown : null, html, recap);
-                }
+                if (options.includeReasoning !== false) prependReasoning(message, recap, format);
             }
 
             conversation.metadataStatus = 'enriched';
@@ -2865,7 +2898,7 @@
                 tokenObtained: Boolean(probeOptions.chatGptAuth.token),
                 accountScoped: Boolean(probeOptions.chatGptAuth.accountId),
                 payloadMessages: result.reason === 'ok'
-                    ? activePayloadMessages(result.body).filter(isMainPayloadMessage).length
+                    ? mainPayloadMessages(activePayloadMessages(result.body)).length
                     : 0
             };
         }

--- a/src/extraction-engine.js
+++ b/src/extraction-engine.js
@@ -1565,8 +1565,23 @@
         return !['thoughts', 'reasoning_recap', 'code', 'execution_output', 'tool_result'].includes(contentType);
     }
 
+    // Reasoning models can store progress updates as ordinary assistant/text
+    // messages in the payload even though the UI renders them inside one
+    // "Worked for…" disclosure. Content type alone cannot distinguish those
+    // updates from the final answer. At the conversation level the distinction
+    // is structural: one user turn may have many assistant records, but only
+    // the last eligible assistant record before the next user turn is the
+    // visible response.
+    function mainPayloadMessages(entries) {
+        const eligible = entries.filter(isMainPayloadMessage);
+        return eligible.filter((entry, index) => {
+            if (entry.message?.author?.role !== 'assistant') return true;
+            return eligible[index + 1]?.message?.author?.role !== 'assistant';
+        });
+    }
+
     function payloadMessageMatches(conversation, entries) {
-        const mainEntries = entries.filter(isMainPayloadMessage);
+        const mainEntries = mainPayloadMessages(entries);
         const byId = new Map(mainEntries.map(entry => [String(entry.message.id || entry.nodeId), entry]));
         const used = new Set();
         const matches = new Map();
@@ -1594,7 +1609,13 @@
 
     function payloadReasoningRecaps(entries) {
         const recaps = new Map();
+        const mainEntries = new Set(mainPayloadMessages(entries));
         let pending = [];
+
+        const appendPending = value => {
+            const text = stripPayloadMarkers(value).trim();
+            if (text && !pending.includes(text)) pending.push(text);
+        };
 
         entries.forEach(entry => {
             const message = entry.message;
@@ -1602,8 +1623,7 @@
             const contentType = String(message?.content?.content_type || '').toLowerCase();
 
             if (role === 'assistant' && contentType === 'reasoning_recap') {
-                const text = payloadContentText(message.content);
-                if (text) pending.push(text);
+                appendPending(payloadContentText(message.content));
                 return;
             }
 
@@ -1612,7 +1632,16 @@
                 return;
             }
 
-            if (role === 'assistant' && isMainPayloadMessage(entry) && pending.length > 0) {
+            // ChatGPT stores the updates shown in its "Worked for…"
+            // disclosure as ordinary assistant/text records immediately before
+            // the visible answer. They are not separate conversation turns,
+            // but dropping them loses content the reader can inspect in the UI.
+            if (role === 'assistant' && isMainPayloadMessage(entry) && !mainEntries.has(entry)) {
+                appendPending(payloadContentText(message.content));
+                return;
+            }
+
+            if (role === 'assistant' && mainEntries.has(entry) && pending.length > 0) {
                 recaps.set(String(message.id || entry.nodeId), pending.join('\n\n'));
                 pending = [];
             }
@@ -2083,6 +2112,16 @@
         message.content = `${message.content}${message.content ? '\n\n' : ''}${markdown !== null ? markdown : html}`.trim();
     }
 
+    function prependReasoning(message, recap, format) {
+        if (!recap || message.content.includes(recap)) return;
+
+        const body = sanitizeHtml(recap).replace(/\n/g, '<br>\n');
+        const markup = format === 'markdown'
+            ? `<small><strong>Reasoning / progress:</strong><br>\n${body}</small>`
+            : `<small class="reasoning-recap"><strong>Reasoning / progress:</strong><br>${body}</small>`;
+        message.content = `${markup}${message.content ? '\n\n' : ''}${message.content}`.trim();
+    }
+
     // ─── Payload-first rendering ────────────────────────────────────────────
     // The payload is the markdown the model produced; the DOM is a rendering of
     // it. Reading the source directly avoids every artifact that comes from
@@ -2096,7 +2135,7 @@
     async function renderConversationFromPayload(payload, doc, provider, options) {
         const format = 'markdown';
         const entries = activePayloadMessages(payload);
-        const mainEntries = entries.filter(isMainPayloadMessage);
+        const mainEntries = mainPayloadMessages(entries);
         if (mainEntries.length === 0) return null;
 
         const recaps = payloadReasoningRecaps(entries);
@@ -2134,9 +2173,7 @@
             }
 
             const recap = recaps.get(String(entry.message.id || entry.nodeId));
-            if (recap && !message.content.includes(recap)) {
-                appendMessageEnrichment(message, `**Reasoning:** ${recap}`, null, recap);
-            }
+            if (options.includeReasoning !== false) prependReasoning(message, recap, format);
 
             const citations = payloadCitations(entry.message);
             if (citations.length > 0) {
@@ -2213,7 +2250,7 @@
         // has. Comparing *ids the sweep actually encountered* — not counts —
         // keeps deliberate content dedupe (two identical "ok" turns collapse by
         // design) from reading as a missing message.
-        const mainEntries = entries.filter(isMainPayloadMessage);
+        const mainEntries = mainPayloadMessages(entries);
         conversation.expectedMessages = mainEntries.length;
         if (options.seenMessageIds instanceof Set) {
             conversation.unreachedMessages = mainEntries.filter(entry =>
@@ -2307,11 +2344,7 @@
 
             const nativeId = String(nativeMessage.id || entry.nodeId);
             const recap = recaps.get(nativeId);
-            if (recap && !message.content.includes(recap)) {
-                const markdown = `**Reasoning:** ${recap}`;
-                const html = `<div class="reasoning-recap"><strong>Reasoning:</strong> ${sanitizeHtml(recap).replace(/\n/g, '<br>')}</div>`;
-                appendMessageEnrichment(message, format === 'markdown' ? markdown : null, html, recap);
-            }
+            if (options.includeReasoning !== false) prependReasoning(message, recap, format);
         }
 
         conversation.metadataStatus = 'enriched';
@@ -2859,7 +2892,7 @@
             tokenObtained: Boolean(probeOptions.chatGptAuth.token),
             accountScoped: Boolean(probeOptions.chatGptAuth.accountId),
             payloadMessages: result.reason === 'ok'
-                ? activePayloadMessages(result.body).filter(isMainPayloadMessage).length
+                ? mainPayloadMessages(activePayloadMessages(result.body)).length
                 : 0
         };
     }

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -1109,7 +1109,8 @@ test('ChatGPT payload enrichment adds timestamps, attachments, generated files, 
 
     assert.equal(conversation.messages[1].timestampIso, new Date(1781030880 * 1000).toISOString());
     assert.match(conversation.messages[1].content, /\[File: ABC_Workbook\.xlsx\]\(sandbox:\/mnt\/data\/ABC_Workbook\.xlsx\)/);
-    assert.match(conversation.messages[1].content, /\*\*Reasoning:\*\* Checked workbook formulas and output paths\./);
+    assert.match(conversation.messages[1].content,
+        /<small><strong>Reasoning \/ progress:<\/strong><br>\nChecked workbook formulas and output paths\.<\/small>/);
     assert.ok(requested.some(url => url.includes('/backend-api/files/download/file-image-api')),
         'image bytes are embedded from the authenticated file endpoint');
     assert.equal(conversation.metadataStatus, 'enriched');
@@ -1211,7 +1212,8 @@ test('a 404 "conversation_inaccessible" is an auth failure, not a missing conver
     assert.equal(conversation.metadataStatus, 'enriched',
         'the page bearer token must be used, not waited for behind a 401 that never comes');
     assert.equal(conversation.messages[0].timestampIso, new Date(1781030820 * 1000).toISOString());
-    assert.match(conversation.messages[1].content, /\*\*Reasoning:\*\* Checked workbook formulas and output paths\./);
+    assert.match(conversation.messages[1].content,
+        /<small><strong>Reasoning \/ progress:<\/strong><br>\nChecked workbook formulas and output paths\.<\/small>/);
 
     const unauthenticated = backend.conversationCalls().filter(call => !call.headers.Authorization);
     assert.equal(unauthenticated.length, 0,
@@ -1332,6 +1334,56 @@ test('Markdown is read from the payload without touching the page', async () => 
         ['user','assistant','user','assistant','user','assistant']);
     assert.ok(conversation.messages.every(message => message.timestampIso),
         'every message carries the payload timestamp');
+});
+
+test('payload reasoning progress is folded into the final response, not exported as separate turns', async () => {
+    // Reasoning models store these updates in the active payload chain as
+    // assistant/text messages, but ChatGPT renders them inside the final
+    // response's "Worked for…" disclosure rather than as conversation turns.
+    const payload = payloadWithMessages(['r1', 'r2', 'r3', 'r4', 'r5', 'r6']);
+    const shapes = [
+        ['user', 'Design the workflow architecture.'],
+        ['assistant', 'I’ll compare the possible runtime boundaries first.'],
+        ['assistant', 'The architecture is converging on a smaller core.'],
+        ['assistant', '# Final design\n\nKeep the portable boundary small.'],
+        ['user', 'Now simplify the update model.'],
+        ['assistant', 'Use a deterministic three-way merge.']
+    ];
+    shapes.forEach(([role, text], index) => {
+        const message = payload.mapping[`node-r${index + 1}`].message;
+        message.author.role = role;
+        message.content.parts = [text];
+    });
+
+    const dom = payloadDom();
+    dom.window.fetch = chatGptBackendStub({ payload }).fetch;
+
+    const conversation = await engine.extractConversationFull({
+        document: dom.window.document, provider: 'chatgpt', format: 'markdown', awaitStreaming: false
+    });
+
+    assert.deepEqual(conversation.messages.map(message => message.senderType),
+        ['user', 'assistant', 'user', 'assistant']);
+    assert.equal(conversation.expectedMessages, 4);
+    assert.match(conversation.messages[1].content, /# Final design/);
+    assert.match(conversation.messages[1].content, /<small><strong>Reasoning \/ progress:<\/strong>/);
+    assert.match(conversation.messages[1].content, /I’ll compare the possible runtime boundaries first\./);
+    assert.match(conversation.messages[1].content, /The architecture is converging on a smaller core\./);
+    assert.ok(conversation.messages[1].content.indexOf('Reasoning / progress:') <
+        conversation.messages[1].content.indexOf('# Final design'),
+    'progress is placed immediately before the answer it led to');
+    assert.equal(conversation.messages.filter(message => message.senderType === 'assistant').length, 2,
+        'progress stays inside its final answer instead of becoming extra turns');
+
+    const withoutReasoning = await engine.extractConversationFull({
+        document: dom.window.document,
+        provider: 'chatgpt',
+        format: 'markdown',
+        awaitStreaming: false,
+        includeReasoning: false
+    });
+    assert.doesNotMatch(withoutReasoning.messages[1].content, /Reasoning \/ progress:/);
+    assert.doesNotMatch(withoutReasoning.messages[1].content, /I’ll compare/);
 });
 
 test('ChatGPT citation markers become sources, not private-use garbage', async () => {


### PR DESCRIPTION
     ChatGPT stores visible “Worked for…” progress as consecutive assistant/text records.
     This change keeps only the final record as the conversation turn while preserving
     preceding progress in a `<small>` block immediately before its answer. Console users
     can omit these blocks by setting `INCLUDE_REASONING = false`.